### PR TITLE
Old Eqmt Data caused Blank Eqmt/Parts to show in Eqmt Window

### DIFF
--- a/WFInfo/Data.cs
+++ b/WFInfo/Data.cs
@@ -328,6 +328,20 @@ namespace WFInfo
             return false;
         }
 
+      /*private JToken AttemptFullParse(JObject database, string[] levels)
+        {
+            JObject curr = database;
+            int i = 0;
+            while (curr != null && curr.TryGetValue(levels[i], out JToken val))
+            {
+                i++;
+                if (i > levels.Length)
+                    return val;
+                curr = val as JObject;
+            }
+            return null;
+        }*/
+
         private void RefreshMarketDucats()
         {
             //equipmentData[primeName]["parts"][partName]["ducats"]

--- a/WFInfo/EquipmentWindow.cs
+++ b/WFInfo/EquipmentWindow.cs
@@ -93,12 +93,18 @@ namespace WFInfo
                             partNode.SetPrimeEqmt(plat, primePart.Value["owned"].ToObject<int>(), primePart.Value["count"].ToObject<int>());
                         }
                         else
-                            Console.WriteLine(primePart.Key + " has no marketValues?");
+                        {
+                            Main.AddLog("COULDN'T FIND MARKET VALUES FOR: " + primePart.Key);
+                            continue;
+                        }
 
                         primeNode.AddChild(partNode);
                     }
-                    primeNode.GetSetInfo();
-                    type.AddChild(primeNode);
+                    if(primeNode.Children.Count() > 0)
+                    {
+                        primeNode.GetSetInfo();
+                        type.AddChild(primeNode);
+                    }
                 }
             }
 


### PR DESCRIPTION
Now if a part doesn't have market data, it gets removed from the window
Also, if a eqmt doesn't have a single part with data, it also gets removed