### PR TITLE
Show vaulted in clipboard

### DIFF
--- a/WFInfo/MainWindow.xaml.cs
+++ b/WFInfo/MainWindow.xaml.cs
@@ -114,9 +114,14 @@ namespace WFInfo
                 if (!Settings.settingsObj.TryGetValue("Delay", out _))
                     Settings.settingsObj["Delay"] = 10000;
                 Settings.delay = Convert.ToInt32(Settings.settingsObj.GetValue("Delay"));
+
                 if (!Settings.settingsObj.TryGetValue("Highlight", out _))
                     Settings.settingsObj["Highlight"] = false;
                 Settings.Highlight = Convert.ToBoolean(Settings.settingsObj.GetValue("Highlight"));
+
+                if (!Settings.settingsObj.TryGetValue("ClipboardVaulted", out _))
+                    Settings.settingsObj["ClipboardVaulted"] = false;
+                Settings.ClipboardVaulted = (bool)Settings.settingsObj.GetValue("ClipboardVaulted");
 
                 Settings.Save();
 

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -295,11 +295,11 @@ namespace WFInfo
 
                             if (platinum > 0)
                             {
-                                if (clipboard != String.Empty)
-                                {
-                                    clipboard += "-  ";
-                                }
+                                if (clipboard != String.Empty) { clipboard += "-  "; }
+
                                 clipboard += "[" + correctName.Replace(" Blueprint", "") + "]: " + plat + ":platinum: ";
+
+                                if (Settings.ClipboardVaulted && vaulted) { clipboard += "[V]"; }
                             }
 
                             if ((partNumber == firstChecks.Length - 1) && (clipboard != String.Empty))
@@ -445,11 +445,12 @@ namespace WFInfo
                             string volume = job["volume"].ToObject<string>();
                             bool vaulted = Main.dataBase.IsPartVaulted(secondName);
                             string partsOwned = Main.dataBase.PartsOwned(secondName);
+                            string partsCount = Main.dataBase.PartsCount(secondName);
 
                             Main.RunOnUIThread(() =>
                             {
                                 if (Settings.isOverlaySelected) {
-                                    Main.overlays[partNumber].LoadTextData(secondName, plat, ducats, volume, vaulted, partsOwned, hideRewardInfo);
+                                    Main.overlays[partNumber].LoadTextData(secondName, plat, ducats, volume, vaulted, partsOwned + "/" + partsCount, hideRewardInfo);
                                 } else {
                                     Main.window.loadTextData(secondName, plat, ducats, volume, vaulted, partsOwned, partNumber, false, hideRewardInfo);
                                 }

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -297,9 +297,9 @@ namespace WFInfo
                             {
                                 if (clipboard != String.Empty) { clipboard += "-  "; }
 
-                                clipboard += "[" + correctName.Replace(" Blueprint", "") + "]: " + plat + ":platinum: ";
+                                clipboard += "[" + correctName.Replace(" Blueprint", "") + "]: " + plat + ":platinum: " + ducats + ":ducats:";
 
-                                if (Settings.ClipboardVaulted && vaulted) { clipboard += "[V]"; }
+                                if (Settings.ClipboardVaulted && vaulted) { clipboard += "(V)"; }
                             }
 
                             if ((partNumber == firstChecks.Length - 1) && (clipboard != String.Empty))

--- a/WFInfo/Settings.xaml.cs
+++ b/WFInfo/Settings.xaml.cs
@@ -58,6 +58,7 @@ namespace WFInfo
         public static bool clipboard { get; internal set; }
         public static bool detectScaling { get; internal set; }
         public static bool SnapitExport { get; internal set; }
+        public static bool ClipboardVaulted { get; internal set; }
 
         public Settings()
         {


### PR DESCRIPTION
Ability to now toggle if you want clipboard to also show vaulted items. Note, this is only enabled in the settings menu as this is not intended to be used by the masses. It's recommended to alter the ad section as well if you're enabling this to explain what the V means. 