### PR TITLE
Added a Fullscreen error popup

### DIFF
--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -1688,7 +1688,7 @@ namespace WFInfo
                     // Assume Fullscreen, don't do anything
                     Main.AddLog($"Fullscreen detected (0x{styles.ToString("X8", Main.culture)}, {window.ToString()}");
                     currentStyle = WindowStyle.FULLSCREEN;
-                    //Show the Fullscreen prompt  ICILEFULLSCREEN
+                    //Show the Fullscreen prompt
                     if (Settings.isOverlaySelected)
                     {
                         Main.AddLog($"Showing the Fullscreen Reminder");

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -1688,7 +1688,17 @@ namespace WFInfo
                     // Assume Fullscreen, don't do anything
                     Main.AddLog($"Fullscreen detected (0x{styles.ToString("X8", Main.culture)}, {window.ToString()}");
                     currentStyle = WindowStyle.FULLSCREEN;
+                    //Show the Fullscreen prompt  ICILEFULLSCREEN
+                    if (Settings.isOverlaySelected)
+                    {
+                        Main.AddLog($"Showing the Fullscreen Reminder");
+                        Main.RunOnUIThread(() =>
+                        {
+                            Main.SpawnFullscreenReminder();
+                        });
+                    }
                 }
+                    
                 center = new Point(window.X + window.Width / 2, window.Y + window.Height / 2);
                 RefreshScaling();
             }

--- a/WFInfo/WFInfo.csproj
+++ b/WFInfo/WFInfo.csproj
@@ -199,6 +199,9 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="fullscreenReminder.xaml.cs">
+      <DependentUpon>fullscreenReminder.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ListingHelper.xaml.cs">
       <DependentUpon>ListingHelper.xaml</DependentUpon>
     </Compile>
@@ -249,6 +252,10 @@
     <Compile Include="RewardWindow.xaml.cs">
       <DependentUpon>RewardWindow.xaml</DependentUpon>
     </Compile>
+    <Page Include="fullscreenReminder.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="ListingHelper.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/WFInfo/fullscreenReminder.xaml
+++ b/WFInfo/fullscreenReminder.xaml
@@ -1,0 +1,21 @@
+<Window x:Class="WFInfo.FullscreenReminder"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:WFInfo"
+        mc:Ignorable="d"
+        Title="fullscreenReminder" Height="130" Width="300" BorderBrush="#FF707070" WindowStyle="None" ResizeMode="NoResize">
+    <Grid Background="#FF1B1B1B" MouseDown="MouseDown">
+
+        <Rectangle Stroke="#FF707070"/>
+        <Rectangle HorizontalAlignment="Left" Height="25" Stroke="#FF646464" VerticalAlignment="Top" Width="300" Fill="#FF0F0F0F"/>
+        <Label x:Name="errorText" Content="Fullscreen detected " HorizontalAlignment="Left" HorizontalContentAlignment="Center" VerticalAlignment="Top" Height="32" Margin="1,23,0,0" Width="298" FontSize="18"/>
+        <TextBlock Margin="15,52,15,0" TextWrapping="Wrap" Text="To make the overlay display over top of the game you need to run the game in borderless fullscreen or window" TextAlignment="Center" VerticalAlignment="Top" Height="53"/>
+        <Button Content="Change game display" HorizontalAlignment="Left" Margin="164,100,0,0" VerticalAlignment="Top" Width="121" Background="#FF0F0F0F" Click="NoClick"/>
+        <Button Content="Disable overlay" Margin="26,100,185,0" VerticalAlignment="Top" Background="#FF0F0F0F" Click="DisableOverlayClick"/>
+        <Image HorizontalAlignment="Left" Height="23" VerticalAlignment="Center" Width="24" Source="Resources/WFLogo.png" Margin="1,0,0,107" >
+        </Image>
+        <TextBlock Text="WFinfo" Margin="26,3,0,106" TextAlignment="Left" Background="{x:Null}" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="16" Height="21" Width="129" RenderTransformOrigin="0.5,0.5"/>
+    </Grid>
+</Window>

--- a/WFInfo/fullscreenReminder.xaml.cs
+++ b/WFInfo/fullscreenReminder.xaml.cs
@@ -1,0 +1,40 @@
+﻿using System.Windows;
+using System.Windows.Input;
+
+namespace WFInfo
+{
+    public partial class FullscreenReminder : Window
+    {
+
+        public FullscreenReminder()
+        {
+            InitializeComponent();
+            Show();
+            Focus();
+        }
+        
+        private void DisableOverlayClick(object sender, RoutedEventArgs e)
+        {
+            Main.AddLog($"[Fullscreen Reminder] User selected \"Disable overlay mode\" - showing Setting window");
+            Main.settingsWindow.Show();
+            Main.settingsWindow.populate();
+            Main.settingsWindow.Left = Left;
+            Main.settingsWindow.Top = Top + Height;
+            Main.settingsWindow.Show();
+            Close();
+
+        }
+        private void NoClick(object sender, RoutedEventArgs e)
+        {
+            Main.AddLog($"[Fullscreen Reminder] User selected \"Do nothing\"");
+            Close();
+        }
+
+        // Allows the draging of the window
+        private new void MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ChangedButton == MouseButton.Left)
+                DragMove();
+        }
+    }
+}


### PR DESCRIPTION
When the OCR triggers, if Warframe runs in fullscreen, it will popup a window to inform the user it will not work as intended.

The popup have 2 buttons : 
 * "Disable Overlay" - will open the settings, letting the user choose by himself which mode he wants
 * "Change game display" - just close the window

note : this window only triggers on the FIRST activation after the launch IF the display mode is on overlay