### PR TITLE
Overlay Offset in options (#136)

### DIFF
--- a/WFInfo/MainWindow.xaml.cs
+++ b/WFInfo/MainWindow.xaml.cs
@@ -185,6 +185,14 @@ namespace WFInfo
                 Settings.settingsObj["HighContrast"] = false;
             Settings.highContrast = (bool)Settings.settingsObj.GetValue("HighContrast");
 
+            if (!Settings.settingsObj.TryGetValue("OverlayXOffsetValue", out _))
+                Settings.settingsObj["OverlayXOffsetValue"] = 0;
+            Settings.overlayXOffsetValue = Convert.ToInt32(Settings.settingsObj.GetValue("OverlayXOffsetValue"), Main.culture);
+
+            if (!Settings.settingsObj.TryGetValue("OverlayYOffsetValue", out _))
+                Settings.settingsObj["OverlayYOffsetValue"] = 0;
+            Settings.overlayYOffsetValue = Convert.ToInt32(Settings.settingsObj.GetValue("OverlayYOffsetValue"), Main.culture);
+
             if (!Settings.settingsObj.TryGetValue("AutoList", out _))
                 Settings.settingsObj["AutoList"] = false;
             Settings.automaticListing = (bool)Settings.settingsObj.GetValue("AutoList");

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -322,8 +322,7 @@ namespace WFInfo
                             {
                                 Main.overlays[partNumber].LoadTextData(correctName, plat, ducats, volume, vaulted, $"{partsOwned} / {partsCount}", hideRewardInfo);
                                 Main.overlays[partNumber].Resize(overWid);
-                                Main.overlays[partNumber].Display((int)((startX + width / 4 * partNumber) / dpiScaling), startY, Settings.delay);
-
+                                Main.overlays[partNumber].Display((int)((startX + width / 4 * partNumber + Settings.overlayXOffsetValue) / dpiScaling), startY + (int)(Settings.overlayYOffsetValue / dpiScaling), Settings.delay);
                             }
                             else if (!Settings.isLightSlected)
                             {

--- a/WFInfo/Settings.xaml
+++ b/WFInfo/Settings.xaml
@@ -7,7 +7,7 @@
         xmlns:local="clr-namespace:WFInfo"
         xmlns:System="clr-namespace:System;assembly=mscorlib"
         mc:Ignorable="d" 
-        Title="Settings" Height="392" Width="334" BorderBrush="#FF707070" WindowStyle="None" ResizeMode="NoResize">
+        Title="Settings" Height="462" Width="334" BorderBrush="#FF707070" WindowStyle="None" ResizeMode="NoResize">
     <Window.Resources>
         <System:Double x:Key="FontSize">18</System:Double>
     </Window.Resources>
@@ -40,6 +40,14 @@
             <Viewbox Margin="188,39,0,0" Height="20" VerticalAlignment="Top" HorizontalAlignment="Left" Width="123" >
                 <CheckBox x:Name="HighContrastCheckbox" Content="High contrast" ToolTip="Enable High contrast for the overlay." VerticalContentAlignment="Center" Background="#FFB1D0D9" BorderBrush="#FF0F0F0F" Click="HighContrastCheckbox_Click"/>
             </Viewbox>
+        </Grid>
+        <Grid x:Name="Overlay_sliders" HorizontalAlignment="Left" Margin="0,149,0,0" Width="334" Height="70" VerticalAlignment="Top">
+          <Rectangle Stroke="#FF646464" Margin="0,-1,0,0"/>
+          <Label Content="Overlay Offset" VerticalAlignment="Top" HorizontalAlignment="Left" HorizontalContentAlignment="Center" Width="335" Height="31" FontSize="{DynamicResource FontSize}" FontFamily="{StaticResource Roboto}" Margin="0,0,-1,0"/>
+            <Label Content="X" Margin="15,30,0,0" FontSize="{DynamicResource FontSize}" HorizontalAlignment="Left" HorizontalContentAlignment="Center" Width="32" Padding="5,5,5,0" Height="35" VerticalAlignment="Top" ToolTip="The X Offset of the overlay. Positive values shift the overlay to the right."/>
+          <TextBox x:Name="OverlayXOffset_number_box" ToolTip="The X Offset of the overlay. Positive values shift the overlay to the right." Margin="45,30,0,0" TextWrapping="Wrap" FontSize="{DynamicResource FontSize}" Background="#FF0F0F0F" BorderBrush="#FFB1D0D9" Height="28" Width="90" VerticalContentAlignment="Center" RenderTransformOrigin="0.5,0.451" HorizontalContentAlignment="Center" Padding="0,0,0,2.5" KeyDown="OverlayXOffset_number_box_KeyDown" Cursor="Arrow" GotFocus="OverlayXOffset_number_box_GotFocus" KeyUp="OverlayXOffset_number_box_KeyUp" VerticalAlignment="Top" HorizontalAlignment="Left" Text="0"/>
+            <Label Content="Y" Margin="183,30,0,0" FontSize="{DynamicResource FontSize}" HorizontalAlignment="Left" HorizontalContentAlignment="Center" Width="32" Padding="5,5,5,0" Height="35" VerticalAlignment="Top" RenderTransformOrigin="5.729,-0.505" ToolTip="The Y Offset of the overlay. Positive values shift the overlay towards the top."/>
+            <TextBox x:Name="OverlayYOffset_number_box" ToolTip="The Y Offset of the overlay. Positive values shift the overlay towards the top." Margin="0,30,30,0" TextWrapping="Wrap" FontSize="{DynamicResource FontSize}" Background="#FF0F0F0F" BorderBrush="#FFB1D0D9" Height="28" Width="90" VerticalContentAlignment="Center" RenderTransformOrigin="0.5,0.451" HorizontalContentAlignment="Center" Padding="0,0,0,2.5" KeyDown="OverlayYOffset_number_box_KeyDown" Cursor="Arrow" GotFocus="OverlayYOffset_number_box_GotFocus" KeyUp="OverlayYOffset_number_box_KeyUp" VerticalAlignment="Top" HorizontalAlignment="Right" Text="0"/>
         </Grid>
         <Grid x:Name="Activation_key" Margin="0,0,0,126" Height="117" VerticalAlignment="Bottom">
             <Rectangle x:Name="First_window2" Stroke="#FF646464" Margin="0,-1,0,0" Fill="#FF1B1B1B"/>


### PR DESCRIPTION
* added ability to adjust the overlays position through an offset option in the settings using the provided sliders or text boxes

* scaled the offsets by the dpi scaling to better match user expectations when displacing against varying dpi scales, also added a restart note for changing the offset

* removed the overlay offset sliders from settings, and inverted the overlay offset external Y values for better ux

* added a clamp to the width and height for the overlay offset