### PR TITLE
Fixed Relic sort & added Relic Era plat sums

### DIFF
--- a/WFInfo/RelicsWindow.cs
+++ b/WFInfo/RelicsWindow.cs
@@ -276,6 +276,7 @@ namespace WFInfo
                 head.RecolorChildren();
                 RelicTree.Items.Add(head);
             }
+            SortBoxChanged(null, null);
             #endregion
         }
     }

--- a/WFInfo/RelicsWindow.cs
+++ b/WFInfo/RelicsWindow.cs
@@ -112,6 +112,7 @@ namespace WFInfo
             }
             else
                 ReapplyFilters();
+            
         }
 
         private void TextboxTextChanged(object sender, TextChangedEventArgs e)
@@ -242,6 +243,9 @@ namespace WFInfo
             int eraNum = 0;
             foreach (TreeNode head in RelicNodes)
             {
+                double sumIntact = 0;
+                double sumRad = 0;
+
                 head.SortNum = eraNum++;
                 foreach (JProperty prop in Main.dataBase.relicData[head.Name])
                 {
@@ -254,15 +258,29 @@ namespace WFInfo
                         if (kvp.Key != "vaulted" && Main.dataBase.marketData.TryGetValue(kvp.Value.ToString(), out JToken marketValues))
                         {
                             TreeNode part = new TreeNode(kvp.Value.ToString(), "", 0);
-                            part.SetPartText(marketValues["plat"].ToObject<double>(), marketValues["ducats"].ToObject<int>(), kvp.Key);
+                            part.SetPartText(marketValues["plat"].ToObject<double>(), marketValues["ducats"].ToObject<int>(), kvp.Key);                           
                             relic.AddChild(part);
                         }
                     }
+                    
                     relic.SetRelicText();
                     head.AddChild(relic);
+                    if (vaulted.Length == 0)
+                    {
+                        sumIntact += double.Parse(relic.Col1_Text2);
+                        sumRad += double.Parse(relic.Col2_Text2);
+                       
+                    }
                     //groupedByAll.Items.Add(relic);
                     //Search.Items.Add(relic);
                 }
+                double delta = sumRad - sumIntact;
+                head.Name = string.Format("{0, -6} INT:{1, -6} RAD:{2, -6} Delta:{3, -6}",
+                                            head.Name,
+                                            sumIntact.ToString("F1"),
+                                            sumRad.ToString("F1"),
+                                            delta.ToString("F1")
+                                         );
                 head.ResetFilter();
                 head.FilterOutVaulted();
                 head.RecolorChildren();

--- a/WFInfo/RelicsWindow.cs
+++ b/WFInfo/RelicsWindow.cs
@@ -265,22 +265,12 @@ namespace WFInfo
                     
                     relic.SetRelicText();
                     head.AddChild(relic);
-                    if (vaulted.Length == 0)
-                    {
-                        sumIntact += double.Parse(relic.Col1_Text2);
-                        sumRad += double.Parse(relic.Col2_Text2);
-                       
-                    }
+
                     //groupedByAll.Items.Add(relic);
                     //Search.Items.Add(relic);
                 }
-                double delta = sumRad - sumIntact;
-                head.Name = string.Format("{0, -6} INT:{1, -6} RAD:{2, -6} Delta:{3, -6}",
-                                            head.Name,
-                                            sumIntact.ToString("F1"),
-                                            sumRad.ToString("F1"),
-                                            delta.ToString("F1")
-                                         );
+
+                head.SetEraText();   
                 head.ResetFilter();
                 head.FilterOutVaulted();
                 head.RecolorChildren();

--- a/WFInfo/RelicsWindow.xaml
+++ b/WFInfo/RelicsWindow.xaml
@@ -83,7 +83,7 @@
                         <HierarchicalDataTemplate.Resources>
                             <Style TargetType="{x:Type TextBlock}">
                                 <Setter Property="FontSize" Value="13" />
-                                <Setter Property="FontFamily" Value="{StaticResource Roboto}" />
+                                <Setter Property="FontFamily" Value="{StaticResource Roboto_Mono}" />
                                 <Setter Property="Foreground" Value="#FFB1D0D9" />
                                 <Setter Property="Padding" Value="0,2,0,0" />
                             </Style>

--- a/WFInfo/RelicsWindow.xaml
+++ b/WFInfo/RelicsWindow.xaml
@@ -6,15 +6,15 @@
         mc:Ignorable="d"
         xmlns:local="clr-namespace:WFInfo"
         x:Class="WFInfo.RelicsWindow"
-        Title="Relics" Height="400" Width="450" WindowStyle="None" AllowsTransparency="True" ResizeMode="CanResizeWithGrip" MaxWidth="450" MinWidth="450" MinHeight="200" Loaded="WindowLoaded">
+        Title="Relics" Height="400" Width="550" WindowStyle="None" AllowsTransparency="True" ResizeMode="CanResizeWithGrip" MaxWidth="550" MinWidth="550" MinHeight="200" Loaded="WindowLoaded">
     <Window.Resources>
 
     </Window.Resources>
 
     <Grid MouseDown="MouseDown">
         <Rectangle Fill="#FF1B1B1B" Stroke="#FF646464" />
-        <Label MouseLeftButtonDown="ExpandAll" Content="＋" FontSize="15" ToolTip="Expand All Levels" Padding="0" Margin="0,26,429,0" Style="{StaticResource Label_Button}" Height="20" VerticalAlignment="Top"/>
-        <Label MouseLeftButtonDown="CollapseAll" Content="－" FontSize="15" ToolTip="Collapse All Levels" Padding="0" Margin="20,26,409,0" Style="{StaticResource Label_Button}" Height="20" VerticalAlignment="Top"/>
+        <Label MouseLeftButtonDown="ExpandAll" Content="＋" FontSize="15" ToolTip="Expand All Levels" Padding="0" Margin="0,26,529,0" Style="{StaticResource Label_Button}" Height="20" VerticalAlignment="Top"/>
+        <Label MouseLeftButtonDown="CollapseAll" Content="－" FontSize="15" ToolTip="Collapse All Levels" Padding="0" Margin="20,26,509,0" Style="{StaticResource Label_Button}" Height="20" VerticalAlignment="Top"/>
 
         <Grid Height="18" VerticalAlignment="Top" Margin="1,27,1,0">
             <Rectangle Fill="#FF0F0F0F" Stroke="#FF646464" Margin="-1"/>
@@ -24,7 +24,7 @@
             <Label Content="Filter:" HorizontalAlignment="Left" Margin="155,0,0,0" Padding="0" VerticalContentAlignment="Center" />
 
         </Grid>
-        <Label x:Name="relicComboButton" MouseLeftButtonDown="ToggleShowAllRelics" Content="Relic Eras" FontSize="12" FontWeight="Normal" Margin="0,45,379,0" Style="{StaticResource Label_Button}" Height="20" VerticalAlignment="Top"/>
+        <Label x:Name="relicComboButton" MouseLeftButtonDown="ToggleShowAllRelics" Content="Relic Eras" FontSize="12" FontWeight="Normal" Margin="0,45,479,0" Style="{StaticResource Label_Button}" Height="20" VerticalAlignment="Top"/>
         <Grid Margin="1,46,1,0" Height="18" VerticalAlignment="Top">
 
 
@@ -91,8 +91,8 @@
                         <Grid Visibility="{Binding Grid_Shown}" Background="{Binding Background_Color}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="80" />
-                                <ColumnDefinition Width="135" />
+                                <ColumnDefinition Width="100" />
+                                <ColumnDefinition Width="155" />
                             </Grid.ColumnDefinitions>
 
                             <StackPanel Orientation="Horizontal" Grid.Column="0" Grid.Row="0">

--- a/WFInfo/TreeNode.cs
+++ b/WFInfo/TreeNode.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows;
@@ -221,10 +222,10 @@ namespace WFInfo
             foreach (TreeNode node in Children)
             {
 
-                if (node.IsVaulted())
+                if (node.IsVaulted()) // IsVaulted is true if its not vaulted
                 {
-                    _intact += double.Parse(node.Col1_Text2);
-                    _radiant += double.Parse(node.Col2_Text2);
+                    _intact += node._intact; 
+                    _radiant += node._radiant; 
 
                 }
             }
@@ -524,8 +525,8 @@ namespace WFInfo
                                 ChildrenFiltered = ChildrenFiltered.AsParallel().OrderByDescending(p => p._bonus).ToList();
                                 break;
                             default:
-                                Children = Children.AsParallel().OrderBy(p => p.Name).ToList();
-                                ChildrenFiltered = ChildrenFiltered.AsParallel().OrderBy(p => p.Name).ToList();
+                                Children = Children.AsParallel().OrderBy(p => PadNumbers(p.Name)).ToList();
+                                ChildrenFiltered = ChildrenFiltered.AsParallel().OrderBy(p => PadNumbers(p.Name)).ToList();
                                 break;
                         }
                     }
@@ -557,13 +558,19 @@ namespace WFInfo
                         //    ChildrenFiltered = ChildrenFiltered.AsParallel().OrderByDescending(p => p._bonus).ToList();
                         //    break;
                         default:
-                            Children = Children.AsParallel().OrderBy(p => p.Name).ToList();
-                            ChildrenFiltered = ChildrenFiltered.AsParallel().OrderBy(p => p.Name).ToList();
+                            Children = Children.AsParallel().OrderBy(p => PadNumbers(p.Name)).ToList();
+                            ChildrenFiltered = ChildrenFiltered.AsParallel().OrderBy(p => PadNumbers(p.Name)).ToList();
                             break;
                     }
                 }
             }
         }
+
+        public static string PadNumbers(string input)
+        {
+            return System.Text.RegularExpressions.Regex.Replace(input, "[0-9]+", match => match.Value.PadLeft(5, '0'));
+        }
+
 
         private string _col1_text1 = "INT:";
         public string Col1_Text1

--- a/WFInfo/TreeNode.cs
+++ b/WFInfo/TreeNode.cs
@@ -213,6 +213,42 @@ namespace WFInfo
             Col2_Img1_Shown = "Hidden";
         }
 
+        public void SetEraText()
+        {
+            _intact = 0;
+            _radiant = 0;
+
+            foreach (TreeNode node in Children)
+            {
+
+                if (node.IsVaulted())
+                {
+                    _intact += double.Parse(node.Col1_Text2);
+                    _radiant += double.Parse(node.Col2_Text2);
+
+                }
+            }
+
+            _bonus = _radiant - _intact;
+
+            Col1_Text1 = "INT:";
+            Col1_Text2 = _intact.ToString("F1");
+
+            Col1_Img1 = PLAT_SRC;
+            Col1_Img1_Shown = "Visible";
+
+            Col2_Text1 = "RAD:";
+            Col2_Text2 = _radiant.ToString("F1");
+            int tempBonus = (int)(_bonus * 10);
+            Col2_Text3 = "(";
+            if (tempBonus >= 0)
+                Col2_Text3 += "+";
+            Col2_Text3 += (tempBonus / 10.0).ToString("F1") + ")";
+
+            Col2_Img1 = PLAT_SRC;
+            Col2_Img1_Shown = "Visible";
+
+        }
         public void SetRelicText()
         {
             _intact = 0;


### PR DESCRIPTION
Added intact & Radiant sum per relic era of unvaulted relics so you can easily see what relics to farm for best efficency
fixed sorting of relics to account for names like 
A1 A11 A2 -> now A1 A2 A11