### PR TITLE
QuadHD wrong bounds fix

### DIFF
--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -941,7 +941,7 @@ namespace WFInfo
                             currentWord = RE.Replace(currentWord, "").Trim();
                             if (currentWord.Length > 0)
                             { //word is valid start comparing to others
-                                var paddedBounds = new Rectangle(bounds.X - bounds.Height / 3, bounds.Y - bounds.Height / 3, bounds.Width + bounds.Height, bounds.Height + bounds.Height / 2);
+                                var paddedBounds = new Rectangle(bounds.X - bounds.Height / 3, bounds.Y - bounds.Height / 3, (int)((bounds.Width + bounds.Height) * screenScaling), bounds.Height + bounds.Height / 2);
 
                                 using (Graphics g = Graphics.FromImage(filteredImage))
                                 {


### PR DESCRIPTION
fix made by @dapal-003, i was only there to write and compile his code

### What did you fix? (provide a description or issue closes statement)
Closed #171 - fixed on discord

---

### Reproduction steps
If screen is quadHD - boundaries are wrong and some items get detected wrong (ex : mag prime set)

---

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter through `npm run lint`? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
