### PR TITLE
SnapIt Horizontal bounds cleanup and settings

### DIFF
--- a/WFInfo/MainWindow.xaml.cs
+++ b/WFInfo/MainWindow.xaml.cs
@@ -231,6 +231,18 @@ namespace WFInfo
                 Settings.settingsObj["SnapItEdgeRadius"] = 1;
             Settings.snapItEdgeRadius = Convert.ToInt32(Settings.settingsObj.GetValue("SnapItEdgeRadius"), Main.culture);
 
+            if (!Settings.settingsObj.TryGetValue("SnapItHorizontalNameMargin", out _))
+                Settings.settingsObj["SnapItHorizontalNameMargin"] = 0;
+            Settings.snapItHorizontalNameMargin = Convert.ToDouble(Settings.settingsObj.GetValue("SnapItHorizontalNameMargin"), Main.culture);
+
+            if (!Settings.settingsObj.TryGetValue("DoCustomNumberBoxWidth", out _))
+                Settings.settingsObj["DoCustomNumberBoxWidth"] = false;
+            Settings.doCustomNumberBoxWidth = (bool)Settings.settingsObj.GetValue("DoCustomNumberBoxWidth");
+
+            if (!Settings.settingsObj.TryGetValue("SnapItNumberBoxWidth", out _))
+                Settings.settingsObj["SnapItNumberBoxWidth"] = 0.4;
+            Settings.snapItNumberBoxWidth = Convert.ToDouble(Settings.settingsObj.GetValue("SnapItNumberBoxWidth"), Main.culture);
+
             Settings.Save();
 
             RegistryKey key = Registry.CurrentUser.CreateSubKey(@"SOFTWARE\WFinfo");

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -966,7 +966,7 @@ namespace WFInfo
                             if (currentWord.Length > 0)
                             { //word is valid start comparing to others
                                 int VerticalPad = bounds.Height/2;
-                                int HorizontalPad = bounds.Height;
+                                int HorizontalPad = (int)(bounds.Height * Settings.snapItHorizontalNameMargin);
                                 var paddedBounds = new Rectangle(bounds.X - HorizontalPad, bounds.Y - VerticalPad, bounds.Width + HorizontalPad * 2, bounds.Height + VerticalPad * 2);
                                 //var paddedBounds = new Rectangle(bounds.X - bounds.Height / 3, bounds.Y - bounds.Height / 3, bounds.Width + bounds.Height, bounds.Height + bounds.Height / 2);
 
@@ -1151,7 +1151,8 @@ namespace WFInfo
                 //set OCR to numbers only
                 firstEngine.SetVariable("tessedit_char_whitelist", "0123456789");
 
-                
+
+                double widthMultiplier = (Settings.doCustomNumberBoxWidth ? Settings.snapItNumberBoxWidth : 0.4);
                 //Process grid system
                 for (int i = 0; i < Rows.Count; i++)
                 {
@@ -1160,7 +1161,7 @@ namespace WFInfo
                         //edges of current area to scan
                         int Left = (j == 0 ? 0 : (Columns[j - 1].Right + Columns[j].X) / 2);
                         int Top = (i == 0 ? 0 : Rows[i - 1].Bottom);
-                        int Width = Math.Min((Columns[j].Right - Left) / 3, filteredImage.Size.Width - Left);
+                        int Width = Math.Min((int)((Columns[j].Right - Left) * widthMultiplier), filteredImage.Size.Width - Left);
                         int Height = Math.Min((Rows[i].Bottom - Top) / 3, filteredImage.Size.Height - Top);
 
                         Rectangle cloneRect = new Rectangle(Left, Top, Width, Height);

--- a/WFInfo/Settings.xaml.cs
+++ b/WFInfo/Settings.xaml.cs
@@ -70,6 +70,9 @@ namespace WFInfo
         public static int snapItCountThreshold;
         public static int snapItEdgeWidth;
         public static int snapItEdgeRadius;
+        public static double snapItHorizontalNameMargin;
+        public static bool doCustomNumberBoxWidth;
+        public static double snapItNumberBoxWidth;
         public static bool auto { get; internal set; }
         public static bool clipboard { get; internal set; }
         public static bool detectScaling { get; internal set; }


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
Horizontal pad for detecting item name overlap in SnapIt removed by default, but can be modified in settings. This is in response to an issue reported by Corgo#6755 on Discord, where certain items (Inaros Prime Chassis Blueprint, Ivara Prime Chassis Blueprint) being next to eachother would cause a bounds overlap on 3440x1440 resolution, which also caused a crash on attempted item count save in said scenario. Also updated the number detection box to adjust for this change, and added settings to enable manual adjustment to said box width.

All new settings are exclusively in file, as they should only be needed to adjust for other issues

---

### Reproduction steps
1. Use SnapIt, with item counting enabled if you want to check the adjustment to the number detection box.
2. Check the resulting SnapItImageBounds image in the debug folder to see the new bounds
3. (optional) change the new settings and repeat from step 1 to see how that affects the outcome. 
"SnapItHorizontalNameMargin" (double) for what multiple of the text height should be used as horizontal pad for text bounds checking
"DoCustomNumberBoxWidth" (boolean) to enable the use of custom number detection box width (next setting)
"SnapItNumberBoxWidth" (double) for what multiple `Number Box Left Edge - Column Right Edge` to use as number box width


---

### Evidence/screenshot/link to line

Just check all changed lines, it's very short

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[In settings file, but rarely needed]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
