### PR TITLE
Kubrow fix

### DIFF
--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -1068,6 +1068,7 @@ namespace WFInfo
         /// <returns>Nothing, but if successful <c>foundItems</c> will be modified</returns>
         private static void GetItemCounts(Bitmap filteredImage, Bitmap filteredImageClean, List<InventoryItem> foundItems, Font font, int threshold)
         {
+            Main.AddLog("Starting Item Counting. Noise Threshold: " + Settings.snapItCountThreshold + ", Edge Width: " + Settings.snapItEdgeWidth + ", Edge Radius: " + Settings.snapItEdgeRadius);
             Pen darkCyan = new Pen(Brushes.DarkCyan);
             Pen red = new Pen(Brushes.Red);
             Pen cyan = new Pen(Brushes.Cyan);

--- a/WFInfo/verifyCount.xaml.cs
+++ b/WFInfo/verifyCount.xaml.cs
@@ -42,22 +42,34 @@ namespace WFInfo
 
         private void SaveClick(object sender, RoutedEventArgs e)
         {
+            bool saveFailed = false;
             foreach (InventoryItem item in latestSnap)
             {
                 if (item.Name.Contains("Prime"))
                 {
                     string[] nameParts = item.Name.Split(new string[] { "Prime" }, 2, StringSplitOptions.None);
                     string primeName = nameParts[0] + "Prime";
-                    string partName = primeName + ( ( nameParts[1].Length > 10 && !nameParts[1].Contains("Kubrow") ) ? nameParts[1].Replace(" Blueprint", "") : nameParts[1]);
+                    string partName = primeName + ( ( nameParts[1].Length > 10 && !nameParts[1].Contains("aKubrow") ) ? nameParts[1].Replace(" Blueprint", "") : nameParts[1]);
 
-                    Console.WriteLine(item.Name);
-                    Console.WriteLine(primeName);
-                    Console.WriteLine(partName);
-                    Main.dataBase.equipmentData[primeName]["parts"][partName]["owned"] = item.Count;
+                    Main.AddLog("Saving count \"" + item.Count + "\" for part \"" + partName + "\"");
+                    try
+                    {
+                        Main.dataBase.equipmentData[primeName]["parts"][partName]["owned"] = item.Count;
+                    }
+                    catch (Exception ex)
+                    {
+                        Main.AddLog("FAILED to save count. Count: " + item.Count + ", Name: " + item.Name + ", primeName: " + primeName + ", partName: " + partName);
+                        saveFailed = true;
+                    }
                 }
             }
             Main.dataBase.SaveAllJSONs();
             EquipmentWindow.INSTANCE.reloadItems();
+            if (saveFailed)
+            {
+                _ = new ErrorDialogue(DateTime.Now, 0); //shouldn't need Main.RunOnUIThread since this is already on the UI Thread
+                Main.StatusUpdate("Failed to save one or more item, report to dev", 2);
+            }
             Hide();
         }
 

--- a/WFInfo/verifyCount.xaml.cs
+++ b/WFInfo/verifyCount.xaml.cs
@@ -48,7 +48,7 @@ namespace WFInfo
                 {
                     string[] nameParts = item.Name.Split(new string[] { "Prime" }, 2, StringSplitOptions.None);
                     string primeName = nameParts[0] + "Prime";
-                    string partName = primeName + ( nameParts[1].Length > 10 ? nameParts[1].Replace(" Blueprint", "") : nameParts[1]);
+                    string partName = primeName + ( ( nameParts[1].Length > 10 && !nameParts[1].Contains("Kubrow") ) ? nameParts[1].Replace(" Blueprint", "") : nameParts[1]);
 
                     Console.WriteLine(item.Name);
                     Console.WriteLine(primeName);

--- a/WFInfo/verifyCount.xaml.cs
+++ b/WFInfo/verifyCount.xaml.cs
@@ -49,7 +49,7 @@ namespace WFInfo
                 {
                     string[] nameParts = item.Name.Split(new string[] { "Prime" }, 2, StringSplitOptions.None);
                     string primeName = nameParts[0] + "Prime";
-                    string partName = primeName + ( ( nameParts[1].Length > 10 && !nameParts[1].Contains("aKubrow") ) ? nameParts[1].Replace(" Blueprint", "") : nameParts[1]);
+                    string partName = primeName + ( ( nameParts[1].Length > 10 && !nameParts[1].Contains("Kubrow") ) ? nameParts[1].Replace(" Blueprint", "") : nameParts[1]);
 
                     Main.AddLog("Saving count \"" + item.Count + "\" for part \"" + partName + "\"");
                     try


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
closed \#180 - Added exception for Kavasa Prime Kubrow Collar on item count save.
Added logging for SnapIt item counting, mainly on count save.

---

### Reproduction steps
1. Use SnapIt with item counting enabled in an area that contains the item "Kavasa Prime Kubrow Collar Blueprint"
2. Select "Save Count" in the count verification dialogue box 
3. (Before fix): WFInfo crashes and item counts are not saved. (After fix): Doesn't crash and successfully saves the item count.

---

### Evidence/screenshot/link to line

Bug fix on line 52 of WFInfo/verifyCount.xaml.cs
Crash tolerance is on line 55-63. 
The rest of the changes are for logging

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
