### PR TITLE
Made mastered items not show up as unowned.

### DIFF
--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -328,7 +328,7 @@ namespace WFInfo
                         }
                         if (duc > 0)
                         {
-                            if (int.Parse(partsOwned, Main.culture) < int.Parse(partsCount, Main.culture))
+                            if (!mastered && int.Parse(partsOwned, Main.culture) < int.Parse(partsCount, Main.culture))
                             {
                                 unownedItems.Add(i);
                             }


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
Mastered items no longer display with the unowned color in the reward screen.

---

### Reproduction steps
1. I marked an equipment as mastered
2. Used a full-screenshot to test reward screen parsing
3. The mastered reward showed up with the unowned color.

---

### Evidence/screenshot/link to line
Test SS:
![test](https://user-images.githubusercontent.com/4091284/128648554-c226687c-947e-4273-b0c4-9ff5336630de.png)


Before fix:
![image](https://user-images.githubusercontent.com/4091284/128648542-cf20312e-a254-48d8-a67a-4ce159dd6cb7.png)

After fix:
![image](https://user-images.githubusercontent.com/4091284/128648507-6cf96c7e-d9d5-45cd-ad4b-ccebb1a51159.png)


### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug fix]**
