### PR TITLE
Snap it and Master it speedup

### DIFF
--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -1638,7 +1638,7 @@ namespace WFInfo
             }
             else
             {
-                partialScreenshotExpanded = image;
+                partialScreenshotExpanded = (Bitmap)image.Clone();
                 filtered = image;
             }
             Color clr;
@@ -1646,7 +1646,7 @@ namespace WFInfo
             int numbytes = Math.Abs(lockedBitmapData.Stride) * lockedBitmapData.Height;
             byte[] LockedBitmapBytes = new byte[numbytes];
             Marshal.Copy(lockedBitmapData.Scan0, LockedBitmapBytes, 0, numbytes);
-            int PixelSize = 3; //24 bits/8 = 3 bytes
+            int PixelSize = 4; //24 bits/8 = 3 bytes
             for (int x = 0; x < filtered.Width; x++)
             {
                 for (int y = 0; y < filtered.Height; y++)
@@ -1657,17 +1657,20 @@ namespace WFInfo
                         LockedBitmapBytes[(y * filtered.Width + x) * PixelSize] = 0;
                         LockedBitmapBytes[(y * filtered.Width + x) * PixelSize + 1] = 0;
                         LockedBitmapBytes[(y * filtered.Width + x) * PixelSize + 2] = 0;
+                        LockedBitmapBytes[(y * filtered.Width + x) * PixelSize + 3] = 0;
                         //filtered.SetPixel(x, y, Color.Black);
                     } else
                     {
                         LockedBitmapBytes[(y * filtered.Width + x) * PixelSize] = 255;
                         LockedBitmapBytes[(y * filtered.Width + x) * PixelSize + 1] = 255;
                         LockedBitmapBytes[(y * filtered.Width + x) * PixelSize + 2] = 255;
+                        LockedBitmapBytes[(y * filtered.Width + x) * PixelSize + 3] = 255;
                         //filtered.SetPixel(x, y, Color.White);
                     }
                 }
             }
             Marshal.Copy(LockedBitmapBytes, 0, lockedBitmapData.Scan0, numbytes);
+            filtered.UnlockBits(lockedBitmapData);
             return filtered;
         }
 

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -1638,7 +1638,6 @@ namespace WFInfo
             }
             else
             {
-                partialScreenshotExpanded = (Bitmap)image.Clone();
                 filtered = image;
             }
             Color clr;
@@ -1646,27 +1645,24 @@ namespace WFInfo
             int numbytes = Math.Abs(lockedBitmapData.Stride) * lockedBitmapData.Height;
             byte[] LockedBitmapBytes = new byte[numbytes];
             Marshal.Copy(lockedBitmapData.Scan0, LockedBitmapBytes, 0, numbytes);
-            int PixelSize = 4; //24 bits/8 = 3 bytes
-            for (int x = 0; x < filtered.Width; x++)
+            int PixelSize = 4; //ARGB, order in array is BGRA
+            for (int i = 0; i < numbytes; i+=PixelSize)
             {
-                for (int y = 0; y < filtered.Height; y++)
-                    {
-                        clr = partialScreenshotExpanded.GetPixel(x, y);
-                    if (ThemeThresholdFilter(clr, active)) 
-                    {
-                        LockedBitmapBytes[(y * filtered.Width + x) * PixelSize] = 0;
-                        LockedBitmapBytes[(y * filtered.Width + x) * PixelSize + 1] = 0;
-                        LockedBitmapBytes[(y * filtered.Width + x) * PixelSize + 2] = 0;
-                        LockedBitmapBytes[(y * filtered.Width + x) * PixelSize + 3] = 0;
-                        //filtered.SetPixel(x, y, Color.Black);
-                    } else
-                    {
-                        LockedBitmapBytes[(y * filtered.Width + x) * PixelSize] = 255;
-                        LockedBitmapBytes[(y * filtered.Width + x) * PixelSize + 1] = 255;
-                        LockedBitmapBytes[(y * filtered.Width + x) * PixelSize + 2] = 255;
-                        LockedBitmapBytes[(y * filtered.Width + x) * PixelSize + 3] = 255;
-                        //filtered.SetPixel(x, y, Color.White);
-                    }
+                clr = Color.FromArgb(LockedBitmapBytes[i + 3], LockedBitmapBytes[i + 2], LockedBitmapBytes[i + 1], LockedBitmapBytes[i]);
+                if (ThemeThresholdFilter(clr, active)) 
+                {
+                    LockedBitmapBytes[i] = 0;
+                    LockedBitmapBytes[i + 1] = 0;
+                    LockedBitmapBytes[i + 2] = 0;
+                    LockedBitmapBytes[i + 3] = 0;
+                    //Black
+                } else
+                {
+                    LockedBitmapBytes[i] = 255;
+                    LockedBitmapBytes[i + 1] = 255;
+                    LockedBitmapBytes[i + 2] = 255;
+                    LockedBitmapBytes[i + 3] = 255;
+                    //White
                 }
             }
             Marshal.Copy(LockedBitmapBytes, 0, lockedBitmapData.Scan0, numbytes);


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
Sped up pixel get and set times for filtering step of Snap It and most of Master It, as suggested by CruleD#8893 on discord ([reference implementation](https://github.com/CruleD/Warframe-ReBa-Farmer/blob/2745fed6a4847659608e19a144fe71b86d256c02/Warframe%20ReBa%20Farmer/Module_RelicScanner.cs#L170))

---

### Reproduction steps
1. Use Snap It or Master It. Debug mode and a few runs per test image recommended to get a good time comparison

---

### Evidence/screenshot/link to line
For the following test image, time went from around 2500ms to around 650 ms. (snap it, whole image due to debug mode, count item disabled)
![FullScreenShot ](https://user-images.githubusercontent.com/77355844/129268260-b6a2dbba-5dc6-4443-ad4c-452e085caff6.png)

For the following test image, time went from around 1600ms to around 1400ms (mastered scan)
![ProfileImage 2021-08-12 15-38-3490](https://user-images.githubusercontent.com/77355844/129268626-bb16a74e-99f0-4b15-8bb9-8ffbb513c2de.png)

For the following test image, time went from **around 12700ms (!!!)** to around 1500ms (mastered scan)
![HighWhiteCloud](https://user-images.githubusercontent.com/77355844/129269018-cc1f3db2-3db0-4dda-b739-296315f91f2e.png)


### Considerations
- Does this contain a new dependency? **[Yes]** (System.Drawing.Imaging)
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Enhancement]**
