### PR TITLE
Multithreaded snap-it

### DIFF
--- a/WFInfo/MainWindow.xaml.cs
+++ b/WFInfo/MainWindow.xaml.cs
@@ -251,7 +251,7 @@ namespace WFInfo
             Settings.snapItNumberBoxWidth = Convert.ToDouble(Settings.settingsObj.GetValue("SnapItNumberBoxWidth"), Main.culture);
 
             if (!Settings.settingsObj.TryGetValue("SnapMultiThreaded", out _))
-                Settings.settingsObj["SnapMultiThreaded"] = false;
+                Settings.settingsObj["SnapMultiThreaded"] = true;
             Settings.snapMultiThreaded = (bool)Settings.settingsObj.GetValue("SnapMultiThreaded");
 
             if (!Settings.settingsObj.TryGetValue("SnapRowTextDensity", out _))

--- a/WFInfo/MainWindow.xaml.cs
+++ b/WFInfo/MainWindow.xaml.cs
@@ -254,6 +254,18 @@ namespace WFInfo
                 Settings.settingsObj["SnapMultiThreaded"] = false;
             Settings.snapMultiThreaded = (bool)Settings.settingsObj.GetValue("SnapMultiThreaded");
 
+            if (!Settings.settingsObj.TryGetValue("SnapRowTextDensity", out _))
+                Settings.settingsObj["SnapRowTextDensity"] = 0.015;
+            Settings.snapRowTextDensity = Convert.ToDouble(Settings.settingsObj.GetValue("SnapRowTextDensity"), Main.culture);
+
+            if (!Settings.settingsObj.TryGetValue("SnapRowEmptyDensity", out _))
+                Settings.settingsObj["SnapRowEmptyDensity"] = 0.01;
+            Settings.snapRowEmptyDensity = Convert.ToDouble(Settings.settingsObj.GetValue("SnapRowEmptyDensity"), Main.culture);
+
+            if (!Settings.settingsObj.TryGetValue("SnapColEmptyDensity", out _))
+                Settings.settingsObj["SnapColEmptyDensity"] = 0.005;
+            Settings.snapColEmptyDensity = Convert.ToDouble(Settings.settingsObj.GetValue("SnapColEmptyDensity"), Main.culture);
+
             Settings.Save();
 
             RegistryKey key = Registry.CurrentUser.CreateSubKey(@"SOFTWARE\WFinfo");

--- a/WFInfo/MainWindow.xaml.cs
+++ b/WFInfo/MainWindow.xaml.cs
@@ -250,6 +250,10 @@ namespace WFInfo
                 Settings.settingsObj["SnapItNumberBoxWidth"] = 0.4;
             Settings.snapItNumberBoxWidth = Convert.ToDouble(Settings.settingsObj.GetValue("SnapItNumberBoxWidth"), Main.culture);
 
+            if (!Settings.settingsObj.TryGetValue("SnapMultiThreaded", out _))
+                Settings.settingsObj["SnapMultiThreaded"] = false;
+            Settings.snapMultiThreaded = (bool)Settings.settingsObj.GetValue("SnapMultiThreaded");
+
             Settings.Save();
 
             RegistryKey key = Registry.CurrentUser.CreateSubKey(@"SOFTWARE\WFinfo");

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -2354,7 +2354,7 @@ namespace WFInfo
             Size FullscreenSize = new Size(image.Width, image.Height);
             using (Graphics graphics = Graphics.FromImage(image))
                 graphics.CopyFromScreen(window.Left, window.Top, 0, 0, FullscreenSize, CopyPixelOperation.SourceCopy);
-            image.Save(Main.AppPath + @"\Debug\FullScreenShot " + timestamp + ".png");
+            image.Save(Main.AppPath + @"\Debug\FullScreenShot " + DateTime.UtcNow.ToString("yyyy-MM-dd HH-mm-ssff", Main.culture) + ".png");
             return image;
         }
 

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -1023,7 +1023,7 @@ namespace WFInfo
             {
                 for ( int j = 0; j < cols.Count; j++)
                 {
-                    Rectangle cloneRect = new Rectangle(cols[j].Item1, rows[i].Item1, cols[j].Item2, rows[i].Item2);
+                    Rectangle cloneRect = new Rectangle(cols[j].Item1 - rowHeight/4, rows[i].Item1 - rowHeight / 4, cols[j].Item2 + rowHeight / 2, rows[i].Item2 + rowHeight / 2);
                     Tuple<Bitmap, Rectangle> temp = Tuple.Create(filteredImageClean.Clone(cloneRect, filteredImageClean.PixelFormat), cloneRect);
                     zones.Add(temp);
                 }

--- a/WFInfo/Settings.xaml
+++ b/WFInfo/Settings.xaml
@@ -76,7 +76,7 @@
                 <CheckBox x:Name="SnapItemCountCheckbox" Content="Count Item" ToolTip="Scan for item amount using Snap-It" VerticalContentAlignment="Center" Background="#FFB1D0D9" BorderBrush="#FF0F0F0F" Click="SnapItemCountCheckbox_Click"/>
             </Viewbox>
             <Viewbox Margin="188,39,0,0" Height="20" VerticalAlignment="Top" HorizontalAlignment="Left" Width="123" >
-                <!--<CheckBox x:Name="SnapItCountCheckbox2" Content="High contrast" ToolTip="Enable High contrast for the overlay." VerticalContentAlignment="Center" Background="#FFB1D0D9" BorderBrush="#FF0F0F0F" Click="SnapItemCountCheckbox2_Click"/> -->
+                <CheckBox x:Name="SnapItThreadCheckbox" Content="Multithread Snap" ToolTip="Speed up snap-it using multithreading" VerticalContentAlignment="Center" Background="#FFB1D0D9" BorderBrush="#FF0F0F0F" Click="SnapItThreadCheckbox_Click"/>
             </Viewbox>
         </Grid>
         <Grid x:Name="Extra_settings" HorizontalAlignment="Left" Width="334" Height="86" VerticalAlignment="Bottom">

--- a/WFInfo/Settings.xaml.cs
+++ b/WFInfo/Settings.xaml.cs
@@ -74,6 +74,7 @@ namespace WFInfo
         public static double snapItHorizontalNameMargin;
         public static bool doCustomNumberBoxWidth;
         public static double snapItNumberBoxWidth;
+        public static bool snapMultiThreaded;
         public static bool auto { get; internal set; }
         public static bool clipboard { get; internal set; }
         public static bool detectScaling { get; internal set; }
@@ -149,6 +150,9 @@ namespace WFInfo
 
             if (Convert.ToBoolean(settingsObj.GetValue("DoSnapItCount")))
                 SnapItemCountCheckbox.IsChecked = true;
+
+            if (Convert.ToBoolean(settingsObj.GetValue("SnapMultiThreaded")))
+                SnapItThreadCheckbox.IsChecked = true;
 
             SnapItCountThreshold_number_box.Text = snapItCountThreshold.ToString(Main.culture);
 
@@ -823,6 +827,13 @@ namespace WFInfo
         {
             settingsObj["DoSnapItCount"] = SnapItemCountCheckbox.IsChecked.Value;
             doSnapItCount = SnapItemCountCheckbox.IsChecked.Value;
+            Save();
+        }
+
+        private void SnapItThreadCheckbox_Click(object sender, RoutedEventArgs e)
+        {
+            settingsObj["SnapMultiThreaded"] = SnapItThreadCheckbox.IsChecked.Value;
+            snapMultiThreaded = SnapItThreadCheckbox.IsChecked.Value;
             Save();
         }
     }

--- a/WFInfo/Settings.xaml.cs
+++ b/WFInfo/Settings.xaml.cs
@@ -75,6 +75,9 @@ namespace WFInfo
         public static bool doCustomNumberBoxWidth;
         public static double snapItNumberBoxWidth;
         public static bool snapMultiThreaded;
+        public static double snapRowTextDensity;
+        public static double snapRowEmptyDensity;
+        public static double snapColEmptyDensity;
         public static bool auto { get; internal set; }
         public static bool clipboard { get; internal set; }
         public static bool detectScaling { get; internal set; }


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
- Fixed FullScreenShot debug image missing timestamp in name
- Fixed status displaying snap-it processing as finished after filtering instead of after actual snap-it processing.
- Added option to multithread snap-it for a siginificant speed improvement.
- When multithreaded snap-it is enabled, also adds white line below every row of text to solve issue of letters/words on different rows fusing together according to the OCR in certain circumstances. 
- Added proper combine order logic when piecing together item names, rather than just relying on the OCR doing it in the right order.

**NOTE**: multithreaded snap-it is currently turned off by default, you may want to change that. 
The splitting of the image for the multithreading is based on density of black pixels on each row and column, this may or may not need tuning in the future for other themes. For now the density numbers are available in the settings file, so they can be modified on the fly if needed.
---

### Reproduction steps
1. Enable "Multithread Snap" in settings (below snap noise)
2. Use snap-it

---

### Evidence/screenshot/link to line

For the text rows fusing together issue, here are a handful of images that experience the issue to test with. Remember that Multithread Snap must be enabled for the fix to be in effect:

(Akjagara Prime Blueprint experiencing the issue)
![FullScreenShot ](https://user-images.githubusercontent.com/77355844/130855864-4e4dc352-b4d6-43b1-a795-b93249329d4e.png)

(Karyst Prime Blueprint, no full image available so you may need to manually force theme to Vitruvian)
![SnapItImage 2021-08-13 22-45-4885](https://user-images.githubusercontent.com/77355844/130856507-bd24430c-2be1-4047-933d-43ef5b2d93a2.png)



### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix/Enhancement]**
