### PR TITLE
Fixed taking screenshots and DPI detection in multi-screen enviroments where screens have different scalings.

### DIFF
--- a/WFInfo/app.manifest
+++ b/WFInfo/app.manifest
@@ -52,7 +52,9 @@
   
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+		<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+		<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+		<gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">false</gdiScaling>
     </windowsSettings>
   </application>
  


### PR DESCRIPTION

### What did you fix? (provide a description or issue closes statement)
The most recent release version does not work correctly with dual-screen setups where screens have different scalings set, and Warframe is being run on the secondary monitor.
This modification allows the program to correctly handle screenshots from other windows and draw the snap-it overlay.

---

### Reproduction steps
1. Set up a dual-screen environment, then set different scalings for the two screens in Windows settings. For example, 150% and 125%.
2. Put Warframe on the secondary screen in borderless windowed mode.
3. Launch WFInfo, open the prime part inventory and activate snap-it mode.
4. Without the provided changes, the selection overlay will display incorrectly, not matching the screen bounds.
5. With them, it displays properly.

---

### Evidence/screenshot/link to line

[Here](#diff-893ae7d9842078a57c8769af12da7b51189e4706b3ece8352092e51d9ff4f1d7R2412) is the code for getting the screen from the handle of the previously detected Warframe process - assuming one exists. If it does not, the application defaults to the primary screen as usual.
[Here](#diff-893ae7d9842078a57c8769af12da7b51189e4706b3ece8352092e51d9ff4f1d7R2367) is the scaling of the snap-it overlay window to the correct size with the DPI of the screen in question.
[This section of the manifest file](#diff-9329aadc5d60cd18f56c6b731caa3768cfa3650838d2a25f299ec6a36995d668R55) allows the application to work with per-monitor DPI settings. Breaks without it.

### Considerations
- Does this contain a new dependency? [No]
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
    - I don't believe this is relevant for this project, correct me if I'm wrong.
- Is is a bug fix, feature request, or enhancement? **[Enhancement]**
