### PR TITLE
Fixed WIndow mode only having mastery checkmark in first slot

### DIFF
--- a/WFInfo/RewardWindow.xaml.cs
+++ b/WFInfo/RewardWindow.xaml.cs
@@ -67,7 +67,7 @@ namespace WFInfo
                     secondDucatText.Text = ducats;
                     secondVolumeText.Text = volume + " sold last 48hrs";
                     secondVaultedMargin.Visibility = vaulted ? Visibility.Visible : Visibility.Hidden;
-                    secondOwnedText.Text = owned.Length > 0 ? owned + " OWNED" : "";
+                    secondOwnedText.Text = owned.Length > 0 ? (mastered ? "✓ " : "") + owned + " OWNED" : "";
                     if (resize)
                         Width = 501;
                     break;
@@ -92,7 +92,7 @@ namespace WFInfo
                     thirdDucatText.Text = ducats;
                     thirdVolumeText.Text = volume + " sold last 48hrs";
                     thirdVaultedMargin.Visibility = vaulted ? Visibility.Visible : Visibility.Hidden;
-                    thirdOwnedText.Text = owned.Length > 0 ? owned + " OWNED" : "";
+                    thirdOwnedText.Text = owned.Length > 0 ? (mastered ? "✓ " : "") + owned + " OWNED" : "";
                     if (resize)
                         Width = 751;
                     break;
@@ -117,7 +117,7 @@ namespace WFInfo
                     fourthDucatText.Text = ducats;
                     fourthVolumeText.Text = volume + " sold last 48hrs";
                     fourthVaultedMargin.Visibility = vaulted ? Visibility.Visible : Visibility.Hidden;
-                    fourthOwnedText.Text = owned.Length > 0 ? owned + " OWNED" : "";
+                    fourthOwnedText.Text = owned.Length > 0 ? (mastered ? "✓ " : "") + owned + " OWNED" : "";
                     if (resize)
                         Width = 1000;
                     break;


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
Fixed the Window mode relic reward display only being able to show mastery status on the first item

---

### Reproduction steps
1. Set the rewards display setting to Window
2. Scan reward screen containing an item marked as mastered in WFInfo in slot 2, 3 or 4

---

### Evidence/screenshot/link to line
It's literally 3 lines, just read it

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
