### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ WFInfo does this by screenshotting the game window, cropping out the part text, 
 # Usage
 1. Download the [latest release](https://github.com/WFCD/WFinfo/releases/latest)
 1. WFinfo requires some aditional software to function properly:
-   1. Download BOTH Microsoft Visual C++ Redistributable 2019 from microsoft [x64](https://aka.ms/vs/16/release/VC_redist.x64.exe) [x86](https://aka.ms/vs/16/release/VC_redist.x86.exe). Make sure you have BOTH installed or it will not work.
+   1. Download BOTH Microsoft Visual C++ Redistributable 2019 from Microsoft [x64](https://aka.ms/vs/16/release/VC_redist.x64.exe) and [x86](https://aka.ms/vs/16/release/VC_redist.x86.exe). Make sure you have BOTH installed or it will not work.
    1. For Windows 7 users: [Enable TLS in registry](https://docs.microsoft.com/en-us/windows-server/security/tls/tls-registry-settings) and ensure you have installed [.NET Framework Runtime 4.8](https://dotnet.microsoft.com/download/dotnet-framework/thank-you/net48-web-installer)
 1. Run WFInfo.exe and wait for it to complete the initial load (databases + OCR data)
 1. Go into warframe game and set the displaymode to `Borderless Fullscreen` and under interface turn `Item Lables` on.


### PR DESCRIPTION
Adding a separator between the links could help people like me not to miss the rest of the explanation. (Especially useful for those who just rush in and skim through information)
