### PR TITLE
Prevent equipment window scrolling on change

### DIFF
--- a/WFInfo/TreeNode.cs
+++ b/WFInfo/TreeNode.cs
@@ -892,10 +892,6 @@ namespace WFInfo
                     Parent.Owned_Capped_Val--;
                     Parent.PrimeUpdateDiff(true);
                 }
-                Main.RunOnUIThread(() =>
-                {
-                    EquipmentWindow.INSTANCE.EqmtTree.Items.Refresh();
-                });
             }
         }
 
@@ -919,10 +915,6 @@ namespace WFInfo
                 Parent.Owned_Capped_Val++;
                 Parent.PrimeUpdateDiff(true);
             }
-            Main.RunOnUIThread(() =>
-            {
-                EquipmentWindow.INSTANCE.EqmtTree.Items.Refresh();
-            });
         }
 
         private void MarkSetAsComplete()
@@ -930,10 +922,6 @@ namespace WFInfo
             Main.dataBase.equipmentData[this.dataRef]["mastered"] = !Mastered;
             Mastered = !Mastered;
             Main.dataBase.SaveAllJSONs();
-            Main.RunOnUIThread(() =>
-            {
-                EquipmentWindow.INSTANCE.EqmtTree.Items.Refresh();
-            });
         }
 
         private void PrimeUpdateDiff(bool UseCappedOwned)


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)

Currently, when you add, remove, or master items on the equipment window it refreshes the treeview which often causes everything to scroll randomly.

This fix prevents the whole treeview from refreshing. Counts seem to update fine without it.

If you're in "Owned" or related sort modes, it doesn't automatically resort, but that would probably be annoying (and doesn't appear to happen in current master anyway)

---

### Reproduction steps
1. Open equipment view
2. Open all four top categories
3. Open an item in each category
4. Scroll halfway down, then add one to an item
5. The treeview scrolls as the Warframe category closes and reopens

---

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
