### PR TITLE
Upgrade libs, adjust locale dropdown style

### DIFF
--- a/Launcher/Launcher.csproj
+++ b/Launcher/Launcher.csproj
@@ -7,6 +7,6 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autoupdater.NET.Official" Version="1.6.0" />
+    <PackageReference Include="Autoupdater.NET.Official" Version="1.7.0" />
   </ItemGroup>
 </Project>

--- a/WFInfo/Settings/SettingsWindow.xaml
+++ b/WFInfo/Settings/SettingsWindow.xaml
@@ -10,7 +10,7 @@
         Title="Settings"
         MaxWidth="334"
         MinWidth="334"
-        Height="594"
+        Height="634"
         BorderBrush="#FF707070"
         WindowStyle="None"
         FontSize="16"

--- a/WFInfo/Settings/SettingsWindow.xaml
+++ b/WFInfo/Settings/SettingsWindow.xaml
@@ -373,7 +373,7 @@
                                           FontFamily="{DynamicResource Roboto}"
                                           Background="#FF1B1B1B"
                                           BorderBrush="#FF0F0F0F"
-                                          Margin="0,4">
+                                          Margin="0,4" Template="{DynamicResource ComboBoxTemplate}" Style="{DynamicResource ComboBoxStyle1}">
                                     <ComboBoxItem Tag="en"
                                                   Content="English"
                                                   FontSize="14"

--- a/WFInfo/Templates/Styles.xaml
+++ b/WFInfo/Templates/Styles.xaml
@@ -90,7 +90,7 @@
     <SolidColorBrush x:Key="ComboBox.Static.Background" Color="#FF0F0F0F"/>
     <SolidColorBrush x:Key="ComboBox.Static.Border" Color="#646464"/>
     <SolidColorBrush x:Key="ComboBox.Static." Color="#FF0F0F0F"/>
-    <SolidColorBrush x:Key="ComboBox.Static.Editable.Background" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="ComboBox.Static.Editable.Background" Color="#FF141414"/>
     <SolidColorBrush x:Key="ComboBox.Static.Editable.Border" Color="#FFABADB3"/>
     <SolidColorBrush x:Key="ComboBox.Static.Editable.Button.Background" Color="Transparent"/>
     <SolidColorBrush x:Key="ComboBox.Static.Editable.Button.Border" Color="Transparent"/>
@@ -100,7 +100,7 @@
         <GradientStop Color="#FF0F0F0F" Offset="1.0"/>
     </LinearGradientBrush>
     <SolidColorBrush x:Key="ComboBox.MouseOver.Border" Color="#FF7EB4EA"/>
-    <SolidColorBrush x:Key="ComboBox.MouseOver.Editable.Background" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="ComboBox.MouseOver.Editable.Background" Color="#FF141414"/>
     <SolidColorBrush x:Key="ComboBox.MouseOver.Editable.Border" Color="#FF7EB4EA"/>
     <LinearGradientBrush x:Key="ComboBox.MouseOver.Editable.Button.Background" EndPoint="0,1" StartPoint="0,0">
         <GradientStop Color="#FFEBF4FC" Offset="0.0"/>
@@ -113,7 +113,7 @@
         <GradientStop Color="#FFC4E0FC" Offset="1.0"/>
     </LinearGradientBrush>
     <SolidColorBrush x:Key="ComboBox.Pressed.Border" Color="#FF569DE5"/>
-    <SolidColorBrush x:Key="ComboBox.Pressed.Editable.Background" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="ComboBox.Pressed.Editable.Background" Color="#FF141414"/>
     <SolidColorBrush x:Key="ComboBox.Pressed.Editable.Border" Color="#FF569DE5"/>
     <LinearGradientBrush x:Key="ComboBox.Pressed.Editable.Button.Background" EndPoint="0,1" StartPoint="0,0">
         <GradientStop Color="#FFDAEBFC" Offset="0.0"/>
@@ -121,9 +121,9 @@
     </LinearGradientBrush>
     <SolidColorBrush x:Key="ComboBox.Pressed.Editable.Button.Border" Color="#FF569DE5"/>
     <SolidColorBrush x:Key="ComboBox.Disabled.Glyph" Color="#FFBFBFBF"/>
-    <SolidColorBrush x:Key="ComboBox.Disabled.Background" Color="#FFF0F0F0"/>
+    <SolidColorBrush x:Key="ComboBox.Disabled.Background" Color="#FF141414"/>
     <SolidColorBrush x:Key="ComboBox.Disabled.Border" Color="#FFD9D9D9"/>
-    <SolidColorBrush x:Key="ComboBox.Disabled.Editable.Background" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="ComboBox.Disabled.Editable.Background" Color="#FF141414"/>
     <SolidColorBrush x:Key="ComboBox.Disabled.Editable.Border" Color="#FFBFBFBF"/>
     <SolidColorBrush x:Key="ComboBox.Disabled.Editable.Button.Background" Color="Transparent"/>
     <SolidColorBrush x:Key="ComboBox.Disabled.Editable.Button.Border" Color="Transparent"/>

--- a/WFInfo/WFInfo.csproj
+++ b/WFInfo/WFInfo.csproj
@@ -71,27 +71,27 @@
     <Content Include="FodyWeavers.xsd" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autoupdater.NET.Official" Version="1.6.0" />
-    <PackageReference Include="Costura.Fody" Version="5.6.0">
+    <PackageReference Include="Autoupdater.NET.Official" Version="1.7.0" />
+    <PackageReference Include="Costura.Fody" Version="5.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="DotNetZip" Version="1.13.7" />
-    <PackageReference Include="Fody" Version="6.5.3">
+    <PackageReference Include="DotNetZip" Version="1.16.0" />
+    <PackageReference Include="Fody" Version="6.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Google.Apis.Sheets.v4" Version="1.45.0.1954" />
-    <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="1.0.8" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Google.Apis.Sheets.v4" Version="1.55.0.2371" />
+    <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
     <PackageReference Include="SuperSocket.ClientEngine.Core" Version="0.10.0" />
-    <PackageReference Include="System.Management" Version="5.0.0" />
-    <PackageReference Include="System.Net.Security" Version="4.3.1" />
-    <PackageReference Include="System.Resources.Extensions" Version="5.0.0" />
+    <PackageReference Include="System.Management" Version="6.0.0" />
+    <PackageReference Include="System.Net.Security" Version="4.3.2" />
+    <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="WebSocketSharp-netstandard" Version="1.0.1" />
   </ItemGroup>


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
* Upgraded libs including Foly and AutoUpdater that is supposed to improve DPI scaling and autoupdate permission error handling
* Adjusted style for Locale dropdown to actually be visible on black themed Windows

---

### Reproduction steps
1. Click settings
2. Look at dropdown, try to select any value in dropdown, look at any style discrepancies

![image](https://user-images.githubusercontent.com/2671025/151673469-e4852b60-3b08-4232-a4e8-7cc54d41132a.png)

### Considerations
- Does this contain a new dependency? **No** (but versions go updated!)
- Does this introduce opinionated data formatting or manual data entry? **Maybe**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix & Maintenance**
