### PR TITLE
Store JWT using Windows DPAPI

### DIFF
--- a/WFInfo/Data.cs
+++ b/WFInfo/Data.cs
@@ -1052,67 +1052,6 @@ namespace WFInfo
 			}
 		}
 
-		public static void EncryptFile(string inputFile, string outputFile) {
-			try {
-				using (RijndaelManaged aes = new RijndaelManaged()) {
-					byte[] key = System.Text.ASCIIEncoding.UTF8.GetBytes(e);
-                    aes.Padding = PaddingMode.PKCS7;
-					/* This is for demostrating purposes only. 
-                     * Ideally you will want the IV key to be different from your key and you should always generate a new one for each encryption in other to achieve maximum security*/
-
-                    //Dapal: I would like to implement this secururety feature but at the moment don't have enough time to look into it more.
-					byte[] IV = System.Text.ASCIIEncoding.UTF8.GetBytes(e);
-
-					using (FileStream fsCrypt = new FileStream(outputFile, FileMode.Create)) {
-						using (ICryptoTransform encryptor = aes.CreateEncryptor(key, IV)) {
-							using (CryptoStream cs = new CryptoStream(fsCrypt, encryptor, CryptoStreamMode.Write)) {
-								using (FileStream fsIn = new FileStream(inputFile, FileMode.Open)) {
-									int data;
-									while ((data = fsIn.ReadByte()) != -1) {
-										cs.WriteByte((byte)data);
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-			catch (Exception ex) {
-                Main.AddLog($"Unabble to encpryt file {ex}");
-			}
-		}
-
-        public static void DecryptFile(string inputFile, string outputFile) {
-            try {
-                using (RijndaelManaged aes = new RijndaelManaged()) {
-                    byte[] key = System.Text.ASCIIEncoding.UTF8.GetBytes(e);
-                    aes.Padding = PaddingMode.PKCS7;
-
-                    /* This is for demostrating purposes only. 
-                     * Ideally you will want the IV key to be different from your key and you should always generate a new one for each encryption in other to achieve maximum security*/
-
-                    //Dapal: I would like to implement this secururety feature but at the moment don't have enough time to look into it more.
-                    byte[] IV = System.Text.ASCIIEncoding.UTF8.GetBytes(e);
-
-                    using (FileStream fsCrypt = new FileStream(inputFile, FileMode.Open)) {
-                        using (FileStream fsOut = new FileStream(outputFile, FileMode.Create)) {
-                            using (ICryptoTransform decryptor = aes.CreateDecryptor(key, IV)) {
-                                using (CryptoStream cs = new CryptoStream(fsCrypt, decryptor, CryptoStreamMode.Read)) {
-                                    int data;
-                                    while ((data = cs.ReadByte()) != -1) {
-                                        fsOut.WriteByte((byte)data);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            catch (Exception ex) {
-                Main.AddLog($"Unable to decrpyt file: {ex}");
-            }
-        }
-
         /// <summary>
         ///	Get's the user's login JWT to authenticate future API calls.
         /// </summary>

--- a/WFInfo/MainWindow.xaml.cs
+++ b/WFInfo/MainWindow.xaml.cs
@@ -124,18 +124,7 @@ namespace WFInfo
 
             SettingsWindow.Save();
 
-            try
-            {
-                Data.DecryptFile(Main.AppPath + @"\jwt_encrpyted", Main.AppPath + @"\jwt");
-                Main.dataBase.JWT = File.ReadAllText(Main.AppPath + @"\jwt");
-
-                //Remove the unencrpyed file.
-                File.Delete(Main.AppPath + @"\jwt");
-            }
-            catch (FileNotFoundException e)
-            {
-                Main.AddLog($"{e.Message}, JWT not set");
-            }
+            Main.dataBase.JWT = EncryptedDataService.LoadStoredJWT();
 
         }
 
@@ -180,12 +169,7 @@ namespace WFInfo
             NotifyIcon.Dispose();
             if (Main.dataBase.rememberMe)
             { // if rememberme was checked then save it
-
-                File.WriteAllText(Main.AppPath + @"\jwt", Main.dataBase.JWT);
-                Data.EncryptFile(Main.AppPath + @"\jwt", Main.AppPath + @"\jwt_encrpyted");
-
-                //Remove the unencrpyed file.
-                File.Delete(Main.AppPath + @"\jwt");
+                EncryptedDataService.PersistJWT(Main.dataBase.JWT);
             }
             Application.Current.Shutdown();
         }

--- a/WFInfo/Services/EncryptedDataService.cs
+++ b/WFInfo/Services/EncryptedDataService.cs
@@ -1,0 +1,50 @@
+using System.Data.SqlClient;
+using System.IO;
+using System.Security;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace WFInfo
+{
+    public class EncryptedDataService
+    {
+        private static readonly IDataProtector JwtProtector;
+
+        static EncryptedDataService()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddDataProtection();
+            var services = serviceCollection.BuildServiceProvider();
+            IDataProtectionProvider provider = services.GetService<IDataProtectionProvider>();
+            JwtProtector = provider?.CreateProtector("WFInfo.JWT.v1");
+        } 
+
+        public static string LoadStoredJWT()
+        {
+            try
+            {
+                var fileText = File.ReadAllText(Main.AppPath + @"\jwt_encrypted");
+                return JwtProtector?.Unprotect(fileText);
+            }
+            catch (FileNotFoundException e)
+            {
+                Main.AddLog($"{e.Message}, JWT not set");
+            }
+            catch (CryptographicException e)
+            {
+                Main.AddLog($"{e.Message}, JWT decryption failed");
+            }
+
+            return null;
+        }
+        
+        public static void PersistJWT(string jwt)
+        {
+            var encryptedJWT = JwtProtector?.Protect(jwt);
+            File.WriteAllText(Main.AppPath + @"\jwt_encrypted", encryptedJWT);
+        }
+        
+        
+    }
+}

--- a/WFInfo/WFInfo.csproj
+++ b/WFInfo/WFInfo.csproj
@@ -87,6 +87,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
     <PackageReference Include="SuperSocket.ClientEngine.Core" Version="0.10.0" />
     <PackageReference Include="System.Management" Version="5.0.0" />
@@ -94,5 +95,6 @@
     <PackageReference Include="System.Resources.Extensions" Version="5.0.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="WebSocketSharp-netstandard" Version="1.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="6.0.1" /> 
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)

This swaps to using the ASP.NET Core [data protection api](https://docs.microsoft.com/en-us/aspnet/core/security/data-protection/introduction?view=aspnetcore-6.0) to store credentials.

On Windows, this will encrypt at rest using the user account to encrypt.
---

### Considerations
- Does this contain a new dependency? **Yes**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**
