### PR TITLE
Fixes warframe.market cookie status confusion between login / available

### DIFF
--- a/WFInfo/Data.cs
+++ b/WFInfo/Data.cs
@@ -121,6 +121,11 @@ namespace WFInfo
 
         public bool IsJwtAvailable()
         {
+            return JWT.Length > 300; //check if the token is of the right length
+        }
+
+        public bool IsJwtLoggedIn()
+        {
             return JWT.Length > 500; //check if the token is of the right length
         }
 

--- a/WFInfo/SearchIt.xaml.cs
+++ b/WFInfo/SearchIt.xaml.cs
@@ -31,7 +31,7 @@ namespace WFInfo
             Main.searchBox.Show();
             MainWindow.INSTANCE.Topmost = true;
             Main.searchBox.placeholder.Content = "Search for warframe.market Items";
-            if (!Main.dataBase.IsJwtAvailable())
+            if (!Main.dataBase.IsJwtLoggedIn())
             {
                 Main.searchBox.placeholder.Content = "Please log in first";
                 Main.login.MoveLogin(Left, Main.searchBox.Top - 130);


### PR DESCRIPTION
The recent JWT cookie length check for data sending prevented a login from completing which means the check will always fail as the full login cookie could never be set in a catch 22.

### Considerations
- I 100% just make up the number 300 out of looking at what the cookie length was when I loaded the page after deleing the cookie to sign myself out.  A total guess if this length is reasonable for all users or if the original not null check should still be used for "available" while 500 length should be used for "logged in"
