### PR TITLE
Russian support

### DIFF
--- a/WFInfo/Data.cs
+++ b/WFInfo/Data.cs
@@ -583,13 +583,24 @@ namespace WFInfo
         public int LevenshteinDistance(string s, string t)
         {
             switch(_settings.Locale)
-            {
+            {      
+                case "ru":
+                    //for russian
+                    return LevenshteinDistanceRussian(s, t);
                 case "ko":
                     // for korean
                     return LevenshteinDistanceKorean(s, t);
                 default:
                     return LevenshteinDistanceDefault(s, t);
             }
+        }
+
+        int LevenshteinDistanceRussian(string firstWord, string secondWord)
+        {
+            firstWord = getLocaleNameData(firstWord);
+            firstWord = firstWord.Replace("Чертеж", "").Replace(":","").Trim();
+            secondWord = secondWord.Replace("Чертеж", "").Trim();
+            return LevenshteinDistanceDefault(firstWord, secondWord);    
         }
 
         public int LevenshteinDistanceDefault(string s, string t)
@@ -636,9 +647,14 @@ namespace WFInfo
                     d[i, j] = Math.Min(Math.Min(opt1, opt2), opt3);
                 }
 
-
-
             return d[n, m];
+        }
+        //I don't know why this method exists but korean does so does my
+        public static bool isRussian(String str) 
+        {
+            char c = str[0];
+            if (0x0400 <= c && c <= 0x045F) return true;
+            return false;
         }
 
         public static bool isKorean(String str)
@@ -658,7 +674,8 @@ namespace WFInfo
                 if (marketItem.Key == "version")
                     continue;
                 string[] split = marketItem.Value.ToString().Split('|');
-                if (split[0] == s)
+                //So the first names can end with the Bluperint while second can start with Blueprint (or maybe vice versa, I forgot), I really don't want to fugure out why is that
+                if (split[0].Replace("Blueprint", "").Trim() == s.Replace("Blueprint", "").Trim())
                 {
                     if (split.Length == 3)
                     {

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -788,9 +788,8 @@ namespace WFInfo
         /// <returns>If part name is close enough to valid to actually process</returns>
         internal static bool PartNameValid (string partName)
         {
-            if ((partName.Length < 13 && _settings.Locale == "en") || (partName.Replace(" ", "").Length < 6 && _settings.Locale == "ko") || (partName.Length < 16 &&_settings.Locale == "ru")) // if part name is smaller than "Bo prime handle" skip current part 
+            if ((partName.Length < 13 && _settings.Locale == "en") || (partName.Replace(" ", "").Length < 6 && _settings.Locale == "ko") || (partName.Length < 13 &&_settings.Locale == "ru")) // if part name is smaller than "Bo prime handle" skip current part 
                 //TODO: Add a min character for other locale here.
-                //im just guessing about ru for now
                 return false;
             return true;
         }

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -115,7 +115,7 @@ namespace WFInfo
         // Screen / Resolution Scaling - Used to adjust pixel values to each person's monitor
         public static double screenScaling;
 
-        public static Regex RE = new Regex("[^a-z가-힣]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        public static Regex RE = new Regex("[^a-z가-힣а-я]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         // Pixel measurements for reward screen @ 1920 x 1080 with 100% scale https://docs.google.com/drawings/d/1Qgs7FU2w1qzezMK-G1u9gMTsQZnDKYTEU36UPakNRJQ/edit
         public const int pixleRewardWidth = 968;
@@ -788,8 +788,9 @@ namespace WFInfo
         /// <returns>If part name is close enough to valid to actually process</returns>
         internal static bool PartNameValid (string partName)
         {
-            if ((partName.Length < 13 && _settings.Locale == "en") || (partName.Replace(" ", "").Length < 6 && _settings.Locale == "ko")) // if part name is smaller than "Bo prime handle" skip current part 
+            if ((partName.Length < 13 && _settings.Locale == "en") || (partName.Replace(" ", "").Length < 6 && _settings.Locale == "ko") || (partName.Length < 16 &&_settings.Locale == "ru")) // if part name is smaller than "Bo prime handle" skip current part 
                 //TODO: Add a min character for other locale here.
+                //im just guessing about ru for now
                 return false;
             return true;
         }

--- a/WFInfo/Services/TesseractService.cs
+++ b/WFInfo/Services/TesseractService.cs
@@ -93,7 +93,8 @@ namespace WFInfo
             JObject traineddata_checksums = new JObject
             {
                 {"en", "7af2ad02d11702c7092a5f8dd044d52f"},
-                {"ko", "c776744205668b7e76b190cc648765da"}
+                {"ko", "c776744205668b7e76b190cc648765da"},
+                {"ru", "2e2022eddce032b754300a8188b41419"}
             };
 
             // get trainned data

--- a/WFInfo/Settings/SettingsWindow.xaml
+++ b/WFInfo/Settings/SettingsWindow.xaml
@@ -17,131 +17,131 @@
         d:DataContext="{d:DesignInstance Type=settings:SettingsWindow}"
         AllowsTransparency="True"
         ResizeMode="CanResizeWithGrip">
-	<Grid MouseDown="MouseDown"
+    <Grid MouseDown="MouseDown"
           PreviewMouseDown="ActivationMouseDown"
           Background="#FF1B1B1B"
           MinWidth="334">
-		<Grid.Resources>
+        <Grid.Resources>
 
-			<Style x:Key="NestedBorder"
+            <Style x:Key="NestedBorder"
                    TargetType="Border">
-				<Setter Property="BorderBrush"
+                <Setter Property="BorderBrush"
                         Value="#FF646464" />
-				<Setter Property="Padding"
+                <Setter Property="Padding"
                         Value="5, 2" />
-				<Setter Property="BorderThickness"
+                <Setter Property="BorderThickness"
                         Value="1" />
-			</Style>
-			<Style TargetType="Border">
-				<Setter Property="BorderBrush"
+            </Style>
+            <Style TargetType="Border">
+                <Setter Property="BorderBrush"
                         Value="#FF646464" />
-				<Setter Property="Padding"
+                <Setter Property="Padding"
                         Value="25, 5" />
-				<Setter Property="BorderThickness"
+                <Setter Property="BorderThickness"
                         Value="1" />
-			</Style>
-			<Style x:Key="AllTextBoxes"
+            </Style>
+            <Style x:Key="AllTextBoxes"
                    BasedOn="{StaticResource baseStyle}"
                    TargetType="TextBox">
-				<Setter Property="Background"
+                <Setter Property="Background"
                         Value="#FF0F0F0F" />
-				<Setter Property="BorderBrush"
+                <Setter Property="BorderBrush"
                         Value="#FFB1D0D9" />
-				<Setter Property="VerticalContentAlignment"
+                <Setter Property="VerticalContentAlignment"
                         Value="Center" />
-				<Setter Property="HorizontalContentAlignment"
+                <Setter Property="HorizontalContentAlignment"
                         Value="Center" />
-				<Setter Property="Margin"
+                <Setter Property="Margin"
                         Value="0, 5" />
-				<Setter Property="Padding"
+                <Setter Property="Padding"
                         Value="0,1,0,2.5" />
-				<Setter Property="Cursor"
+                <Setter Property="Cursor"
                         Value="Arrow" />
-				<Setter Property="TextWrapping"
+                <Setter Property="TextWrapping"
                         Value="Wrap" />
-				<Setter Property="FontFamily"
+                <Setter Property="FontFamily"
                         Value="{StaticResource Roboto}" />
-				<Setter Property="components:SelectTextOnFocus.Active"
+                <Setter Property="components:SelectTextOnFocus.Active"
                         Value="True" />
-				<Setter Property="wfInfo:FocusAdvancement.AdvancesByEnterKey"
+                <Setter Property="wfInfo:FocusAdvancement.AdvancesByEnterKey"
                         Value="True" />
-			</Style>
+            </Style>
 
-			<Style TargetType="CheckBox"
+            <Style TargetType="CheckBox"
                    BasedOn="{StaticResource baseStyle}">
-				<Setter Property="Background"
+                <Setter Property="Background"
                         Value="#FFB1D0D9" />
-				<Setter Property="BorderBrush"
+                <Setter Property="BorderBrush"
                         Value="#FF0F0F0F" />
-				<Setter Property="VerticalContentAlignment"
+                <Setter Property="VerticalContentAlignment"
                         Value="Center" />
-			</Style>
-			<Style BasedOn="{StaticResource AllTextBoxes}"
+            </Style>
+            <Style BasedOn="{StaticResource AllTextBoxes}"
                    TargetType="TextBox" />
-			<Style x:Key="KeyBindTextboxStyle"
+            <Style x:Key="KeyBindTextboxStyle"
                    BasedOn="{StaticResource AllTextBoxes}"
                    TargetType="TextBox">
-				<Setter Property="components:SelectTextOnFocus.Active"
+                <Setter Property="components:SelectTextOnFocus.Active"
                         Value="False" />
-				<Style.Triggers>
-					<Trigger Property="IsFocused"
+                <Style.Triggers>
+                    <Trigger Property="IsFocused"
                              Value="True">
-						<Setter Property="Foreground"
+                        <Setter Property="Foreground"
                                 Value="Transparent">
-						</Setter>
-					</Trigger>
-				</Style.Triggers>
-			</Style>
-			<components:NegateIntConverter x:Key="NegateIntConverter" />
-			<components:KeyStringConverter x:Key="KeyStringConverter" />
-		</Grid.Resources>
-		<Grid.ColumnDefinitions>
-			<ColumnDefinition Width="*" />
-			<ColumnDefinition Width="Auto" />
-		</Grid.ColumnDefinitions>
-		<Grid.RowDefinitions>
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="*" />
-		</Grid.RowDefinitions>
-		<Grid VerticalAlignment="Top"
+                        </Setter>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+            <components:NegateIntConverter x:Key="NegateIntConverter" />
+            <components:KeyStringConverter x:Key="KeyStringConverter" />
+        </Grid.Resources>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid VerticalAlignment="Top"
               Grid.Row="0"
               Grid.ColumnSpan="2"
               Grid.Column="0">
-			<Rectangle Fill="#FF0F0F0F"
+            <Rectangle Fill="#FF0F0F0F"
                        Stroke="#FF646464" />
-			<DockPanel>
-				<Image HorizontalAlignment="Left"
+            <DockPanel>
+                <Image HorizontalAlignment="Left"
                        VerticalAlignment="Center"
                        Width="26"
                        DockPanel.Dock="Left"
                        Margin="2,0,5,1"
                        Source="../Resources/WFLogo.png" />
-				<Label MouseLeftButtonDown="Hide"
+                <Label MouseLeftButtonDown="Hide"
                        Content="x"
                        Width="30"
                        Style="{StaticResource Label_Button}"
                        VerticalContentAlignment="Stretch"
                        DockPanel.Dock="Right" />
-				<TextBlock Text="Settings"
+                <TextBlock Text="Settings"
                            VerticalAlignment="Center"
                            FontSize="16"
                            FontFamily="{StaticResource Roboto_Black}"
                            FontWeight="Bold" />
-			</DockPanel>
-		</Grid>
-		<ScrollViewer Grid.Row="1"
+            </DockPanel>
+        </Grid>
+        <ScrollViewer Grid.Row="1"
                       Grid.Column="0">
-			<StackPanel Orientation="Vertical">
-				<Border DockPanel.Dock="Top">
-					<DockPanel>
-						<Grid DockPanel.Dock="Bottom"
+            <StackPanel Orientation="Vertical">
+                <Border DockPanel.Dock="Top">
+                    <DockPanel>
+                        <Grid DockPanel.Dock="Bottom"
                               HorizontalAlignment="Stretch">
-							<Grid.ColumnDefinitions>
-								<ColumnDefinition Width="Auto" />
-								<ColumnDefinition />
-								<ColumnDefinition Width="Auto" />
-							</Grid.ColumnDefinitions>
-							<RadioButton x:Name="WindowRadio"
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <RadioButton x:Name="WindowRadio"
                                          Grid.Column="1"
                                          Content="Window"
                                          ToolTip="Display rewards in a separate window"
@@ -150,7 +150,7 @@
                                          Background="#FFB1D0D9"
                                          BorderBrush="#FF0F0F0F"
                                          HorizontalAlignment="Center" />
-							<RadioButton x:Name="OverlayRadio"
+                            <RadioButton x:Name="OverlayRadio"
                                          Grid.Column="2"
                                          Content="Overlay"
                                          ToolTip="Display rewards on top of Warframe"
@@ -158,7 +158,7 @@
                                          Checked="OverlayChecked"
                                          Background="#FFB1D0D9"
                                          BorderBrush="#FF0F0F0F" />
-							<RadioButton x:Name="LightRadio"
+                            <RadioButton x:Name="LightRadio"
                                          Grid.Column="0"
                                          Content="Light"
                                          ToolTip="Do not display any window at all"
@@ -166,48 +166,48 @@
                                          Checked="LightRadioChecked"
                                          Background="#FFB1D0D9"
                                          BorderBrush="#FF0F0F0F" />
-						</Grid>
-						<Label Content="Rewards display"
+                        </Grid>
+                        <Label Content="Rewards display"
                                DockPanel.Dock="Top"
                                HorizontalAlignment="Center"
                                FontFamily="{StaticResource Roboto}"
                                Margin="0,0,-1,0" />
-					</DockPanel>
-				</Border>
-				<Border DockPanel.Dock="Top">
-					<UniformGrid>
-						<Label Content="Display time" />
-						<TextBox x:Name="Displaytime_number_box"
+                    </DockPanel>
+                </Border>
+                <Border DockPanel.Dock="Top">
+                    <UniformGrid>
+                        <Label Content="Display time" />
+                        <TextBox x:Name="Displaytime_number_box"
                                  ToolTip="The time in milliseconds the overlays will be displayed on screen"
                                  Text="{Binding SettingsViewModel.Delay, Mode=TwoWay}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.,]+$" />
 
-						<CheckBox x:Name="HighlightCheckbox"
+                        <CheckBox x:Name="HighlightCheckbox"
                                   Content="Highlight"
                                   ToolTip="Highlight the best rewards on the overlay."
                                   IsChecked="{Binding SettingsViewModel.HighlightRewards, Mode=TwoWay}" />
-						<CheckBox x:Name="HighContrastCheckbox"
+                        <CheckBox x:Name="HighContrastCheckbox"
                                   Content="High contrast"
                                   ToolTip="Enable High contrast for the overlay."
                                   IsChecked="{Binding SettingsViewModel.HighContrast, Mode=TwoWay}" />
-					</UniformGrid>
-				</Border>
-				<Border x:Name="Overlay_sliders"
+                    </UniformGrid>
+                </Border>
+                <Border x:Name="Overlay_sliders"
                         DockPanel.Dock="Top">
-					<DockPanel LastChildFill="False">
-						<Label Content="Overlay Offset"
+                    <DockPanel LastChildFill="False">
+                        <Label Content="Overlay Offset"
                                DockPanel.Dock="Top"
                                HorizontalAlignment="Center"
                                FontFamily="{StaticResource Roboto}"
                                Margin="0,0,-1,0" />
-						<DockPanel LastChildFill="False"
+                        <DockPanel LastChildFill="False"
                                    DockPanel.Dock="Top">
-							<Label Content="X"
+                            <Label Content="X"
                                    DockPanel.Dock="Left"
                                    HorizontalContentAlignment="Center"
                                    Width="32"
                                    ToolTip="The X Offset of the overlay. Positive values shift the overlay to the right." />
-							<TextBox x:Name="OverlayXOffset_number_box"
+                            <TextBox x:Name="OverlayXOffset_number_box"
                                      DockPanel.Dock="Left"
                                      ToolTip="The X Offset of the overlay. Positive values shift the overlay to the right."
                                      TextWrapping="Wrap"
@@ -215,60 +215,60 @@
                                      components:NumericOnlyEntry.RegexFilter="^-?[0-9]*$"
                                      Width="90" />
 
-							<TextBox x:Name="OverlayYOffset_number_box"
+                            <TextBox x:Name="OverlayYOffset_number_box"
                                      DockPanel.Dock="Right"
                                      ToolTip="The Y Offset of the overlay. Positive values shift the overlay towards the top."
                                      Width="90"
                                      Text="{Binding SettingsViewModel.OverlayYOffsetValue, Mode=TwoWay
                              , Converter={StaticResource NegateIntConverter}}"
                                      components:NumericOnlyEntry.RegexFilter="^-?[0-9]*$" />
-							<Label Content="Y"
+                            <Label Content="Y"
                                    DockPanel.Dock="Right"
                                    HorizontalContentAlignment="Center"
                                    Width="32"
                                    ToolTip="The Y Offset of the overlay. Positive values shift the overlay towards the top." />
-						</DockPanel>
-					</DockPanel>
-				</Border>
-				<Border DockPanel.Dock="Top">
-					<UniformGrid>
-						<Label Content="Snap Noise"
+                        </DockPanel>
+                    </DockPanel>
+                </Border>
+                <Border DockPanel.Dock="Top">
+                    <UniformGrid>
+                        <Label Content="Snap Noise"
                                ToolTip="Snap-It item count noise filtering threshhold" />
-						<TextBox x:Name="SnapItCountThreshold_number_box"
+                        <TextBox x:Name="SnapItCountThreshold_number_box"
                                  ToolTip="Threshold for number detection noise filtering. Higher = More aggressive, 3 or 4 usually works best"
                                  Text="{Binding SettingsViewModel.SnapItCountThreshold, Mode=TwoWay}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.,]+$"
                                  VerticalAlignment="Top" />
 
-						<CheckBox x:Name="SnapItemCountCheckbox"
+                        <CheckBox x:Name="SnapItemCountCheckbox"
                                   Content="Count Item"
                                   ToolTip="Scan for item amount using Snap-It"
                                   IsChecked="{Binding SettingsViewModel.DoSnapItCount, Mode=TwoWay}" />
 
-						<CheckBox x:Name="SnapItThreadCheckbox"
+                        <CheckBox x:Name="SnapItThreadCheckbox"
                                   Content="Multithread Snap"
                                   ToolTip="Speed up snap-it using multithreading"
                                   IsChecked="{Binding SettingsViewModel.SnapMultiThreaded, Mode=TwoWay}" />
 
-					</UniformGrid>
-				</Border>
-				<Border DockPanel.Dock="Top"
+                    </UniformGrid>
+                </Border>
+                <Border DockPanel.Dock="Top"
                         Padding="15 5 25 5">
-					<Grid>
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition />
-							<ColumnDefinition />
-						</Grid.ColumnDefinitions>
-						<Grid.RowDefinitions>
-							<RowDefinition />
-							<RowDefinition />
-							<RowDefinition />
-							<RowDefinition />
-						</Grid.RowDefinitions>
-						<Label Content="Activation key"
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition />
+                            <ColumnDefinition />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition />
+                            <RowDefinition />
+                            <RowDefinition />
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+                        <Label Content="Activation key"
                                Grid.Row="0"
                                Grid.Column="0" />
-						<TextBox x:Name="Activation_key_box"
+                        <TextBox x:Name="Activation_key_box"
                                  Style="{StaticResource KeyBindTextboxStyle}"
                                  Grid.Row="0"
                                  Grid.Column="1"
@@ -277,7 +277,7 @@
                                  IsReadOnly="True"
                                  KeyUp="ActivationUp"
                                  VerticalAlignment="Top" />
-						<TextBlock x:Name="hidden"
+                        <TextBlock x:Name="hidden"
                                    Focusable="True"
                                    Visibility="Visible"
                                    IsEnabled="True"
@@ -289,10 +289,10 @@
                                    Width="1"
                                    RenderTransformOrigin="0.5,0.5"
                                    d:IsHidden="True" />
-						<Label Content="Search it modifier"
+                        <Label Content="Search it modifier"
                                Grid.Row="1"
                                Grid.Column="0" />
-						<TextBox x:Name="Searchit_key_box"
+                        <TextBox x:Name="Searchit_key_box"
                                  Style="{StaticResource KeyBindTextboxStyle}"
                                  Grid.Row="1"
                                  Grid.Column="1"
@@ -302,10 +302,10 @@
                                  Text="{Binding SettingsViewModel.SearchItModifierKey,
                                 Converter={StaticResource KeyStringConverter}}"
                                  VerticalAlignment="Top" />
-						<Label Content="Snap it modifier"
+                        <Label Content="Snap it modifier"
                                Grid.Row="2"
                                Grid.Column="0" />
-						<TextBox x:Name="Snapit_key_box"
+                        <TextBox x:Name="Snapit_key_box"
                                  Style="{StaticResource KeyBindTextboxStyle}"
                                  Grid.Row="2"
                                  Grid.Column="1"
@@ -315,10 +315,10 @@
                                  KeyUp="Snapit_key_box_KeyUp"
                                  IsReadOnly="True"
                                  VerticalAlignment="Top" />
-						<Label Content="Master it modifier"
+                        <Label Content="Master it modifier"
                                Grid.Row="3"
                                Grid.Column="0" />
-						<TextBox x:Name="Masterit_key_box"
+                        <TextBox x:Name="Masterit_key_box"
                                  Style="{StaticResource KeyBindTextboxStyle}"
                                  Grid.Row="3"
                                  Grid.Column="1"
@@ -328,45 +328,45 @@
                                  IsReadOnly="True"
                                  KeyUp="Masterit_key_box_KeyUp"
                                  VerticalAlignment="Top" />
-					</Grid>
-				</Border>
-				<Border DockPanel.Dock="Top"
+                    </Grid>
+                </Border>
+                <Border DockPanel.Dock="Top"
                         Width="334">
-					<UniformGrid>
-						<Label Content="Efficiency min" />
-						<Label Content="Efficiency max" />
-						<TextBox ToolTip="Anything below this efficiency will be marked as red in snapit"
+                    <UniformGrid>
+                        <Label Content="Efficiency min" />
+                        <Label Content="Efficiency max" />
+                        <TextBox ToolTip="Anything below this efficiency will be marked as red in snapit"
                                  Margin="0, 0, 20, 0"
                                  Text="{Binding SettingsViewModel.MinimumEfficiencyValue, Mode=TwoWay}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.,]+$"
                                  AutoWordSelection="True"
                                  VerticalAlignment="Top" />
-						<TextBox ToolTip="Anything above this efficiency will be marked as green in snapit"
+                        <TextBox ToolTip="Anything above this efficiency will be marked as green in snapit"
                                  Text="{Binding SettingsViewModel.MaximumEfficiencyValue, Mode=TwoWay}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.,]+$"
                                  Margin="0, 0, 20, 0"
                                  VerticalAlignment="Top" />
-					</UniformGrid>
-				</Border>
-				<Border Padding="0"
+                    </UniformGrid>
+                </Border>
+                <Border Padding="0"
                         DockPanel.Dock="Top">
-					<DockPanel>
-						<Label MouseLeftButtonDown="ClickCreateDebug"
+                    <DockPanel>
+                        <Label MouseLeftButtonDown="ClickCreateDebug"
                                Padding="5"
                                DockPanel.Dock="Right"
                                Content="Create debug zip"
                                FontWeight="Regular"
                                Style="{StaticResource Label_Button}" />
-						<Border Style="{StaticResource NestedBorder}"
+                        <Border Style="{StaticResource NestedBorder}"
                                 DockPanel.Dock="Top">
-							<UniformGrid DockPanel.Dock="Top"
+                            <UniformGrid DockPanel.Dock="Top"
                                          Rows="1">
 
-								<Label Content="Locale"
+                                <Label Content="Locale"
                                        DockPanel.Dock="Left"
                                        FontSize="16"
                                        FontWeight="Regular" />
-								<ComboBox SelectionChanged="localeComboboxSelectionChanged"
+                                <ComboBox SelectionChanged="localeComboboxSelectionChanged"
                                           DockPanel.Dock="Right"
                                           x:Name="localeCombobox"
                                           FontSize="14"
@@ -374,47 +374,47 @@
                                           Background="#FF1B1B1B"
                                           BorderBrush="#FF0F0F0F"
                                           Margin="0,4" Template="{DynamicResource ComboBoxTemplate}" Style="{DynamicResource ComboBoxStyle1}">
-									<ComboBoxItem Tag="en"
+                                    <ComboBoxItem Tag="en"
                                                   Content="English"
                                                   FontSize="14"
                                                   Background="#FF1B1B1B" />
-									<ComboBoxItem Tag="ko"
+                                    <ComboBoxItem Tag="ko"
                                                   Content="한국어"
                                                   FontSize="14"
                                                   Background="#FF1B1B1B" />
-									<ComboBoxItem Tag="ru"
+                                    <ComboBoxItem Tag="ru"
                                                   Content="Russian"
                                                   FontSize="14"
                                                   Background="#FF1B1B1B" />
-								</ComboBox>
-							</UniformGrid>
-						</Border>
-						<Border DockPanel.Dock="Top"
+                                </ComboBox>
+                            </UniformGrid>
+                        </Border>
+                        <Border DockPanel.Dock="Top"
                                 Style="{StaticResource NestedBorder}">
-							<CheckBox x:Name="clipboardCheckbox"
+                            <CheckBox x:Name="clipboardCheckbox"
                                       Content="Clipboard"
                                       ToolTip="Copy the results from the OCR over to the clipboard for easy pasting into chat"
                                       IsChecked="{Binding SettingsViewModel.Clipboard, Mode=TwoWay}" />
-						</Border>
-						<Border DockPanel.Dock="Top"
+                        </Border>
+                        <Border DockPanel.Dock="Top"
                                 Style="{StaticResource NestedBorder}">
-							<UniformGrid Rows="1">
+                            <UniformGrid Rows="1">
 
-								<CheckBox x:Name="autoCheckbox"
+                                <CheckBox x:Name="autoCheckbox"
                                           DockPanel.Dock="Right"
                                           Content="Auto"
                                           ToolTip="Automatically detects when the relic screen is visible."
                                           Click="AutoClicked" />
-								<CheckBox x:Name="Autolist"
+                                <CheckBox x:Name="Autolist"
                                           DockPanel.Dock="Left"
                                           Content="Auto list"
                                           ToolTip="Spawns a listing dialogue whenever the end of mission is detected, requires auto"
                                           IsChecked="{Binding SettingsViewModel.AutoList, Mode=TwoWay}" />
-							</UniformGrid>
-						</Border>
-					</DockPanel>
-				</Border>
-			</StackPanel>
-		</ScrollViewer>
-	</Grid>
+                            </UniformGrid>
+                        </Border>
+                    </DockPanel>
+                </Border>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
 </Window>

--- a/WFInfo/Settings/SettingsWindow.xaml
+++ b/WFInfo/Settings/SettingsWindow.xaml
@@ -17,131 +17,131 @@
         d:DataContext="{d:DesignInstance Type=settings:SettingsWindow}"
         AllowsTransparency="True"
         ResizeMode="CanResizeWithGrip">
-    <Grid MouseDown="MouseDown"
+	<Grid MouseDown="MouseDown"
           PreviewMouseDown="ActivationMouseDown"
           Background="#FF1B1B1B"
           MinWidth="334">
-        <Grid.Resources>
+		<Grid.Resources>
 
-            <Style x:Key="NestedBorder"
+			<Style x:Key="NestedBorder"
                    TargetType="Border">
-                <Setter Property="BorderBrush"
+				<Setter Property="BorderBrush"
                         Value="#FF646464" />
-                <Setter Property="Padding"
+				<Setter Property="Padding"
                         Value="5, 2" />
-                <Setter Property="BorderThickness"
+				<Setter Property="BorderThickness"
                         Value="1" />
-            </Style>
-            <Style TargetType="Border">
-                <Setter Property="BorderBrush"
+			</Style>
+			<Style TargetType="Border">
+				<Setter Property="BorderBrush"
                         Value="#FF646464" />
-                <Setter Property="Padding"
+				<Setter Property="Padding"
                         Value="25, 5" />
-                <Setter Property="BorderThickness"
+				<Setter Property="BorderThickness"
                         Value="1" />
-            </Style>
-            <Style x:Key="AllTextBoxes"
+			</Style>
+			<Style x:Key="AllTextBoxes"
                    BasedOn="{StaticResource baseStyle}"
                    TargetType="TextBox">
-                <Setter Property="Background"
+				<Setter Property="Background"
                         Value="#FF0F0F0F" />
-                <Setter Property="BorderBrush"
+				<Setter Property="BorderBrush"
                         Value="#FFB1D0D9" />
-                <Setter Property="VerticalContentAlignment"
+				<Setter Property="VerticalContentAlignment"
                         Value="Center" />
-                <Setter Property="HorizontalContentAlignment"
+				<Setter Property="HorizontalContentAlignment"
                         Value="Center" />
-                <Setter Property="Margin"
+				<Setter Property="Margin"
                         Value="0, 5" />
-                <Setter Property="Padding"
+				<Setter Property="Padding"
                         Value="0,1,0,2.5" />
-                <Setter Property="Cursor"
+				<Setter Property="Cursor"
                         Value="Arrow" />
-                <Setter Property="TextWrapping"
+				<Setter Property="TextWrapping"
                         Value="Wrap" />
-                <Setter Property="FontFamily"
+				<Setter Property="FontFamily"
                         Value="{StaticResource Roboto}" />
-                <Setter Property="components:SelectTextOnFocus.Active"
+				<Setter Property="components:SelectTextOnFocus.Active"
                         Value="True" />
-                <Setter Property="wfInfo:FocusAdvancement.AdvancesByEnterKey"
+				<Setter Property="wfInfo:FocusAdvancement.AdvancesByEnterKey"
                         Value="True" />
-            </Style>
+			</Style>
 
-            <Style TargetType="CheckBox"
+			<Style TargetType="CheckBox"
                    BasedOn="{StaticResource baseStyle}">
-                <Setter Property="Background"
+				<Setter Property="Background"
                         Value="#FFB1D0D9" />
-                <Setter Property="BorderBrush"
+				<Setter Property="BorderBrush"
                         Value="#FF0F0F0F" />
-                <Setter Property="VerticalContentAlignment"
+				<Setter Property="VerticalContentAlignment"
                         Value="Center" />
-            </Style>
-            <Style BasedOn="{StaticResource AllTextBoxes}"
+			</Style>
+			<Style BasedOn="{StaticResource AllTextBoxes}"
                    TargetType="TextBox" />
-            <Style x:Key="KeyBindTextboxStyle"
+			<Style x:Key="KeyBindTextboxStyle"
                    BasedOn="{StaticResource AllTextBoxes}"
                    TargetType="TextBox">
-                <Setter Property="components:SelectTextOnFocus.Active"
+				<Setter Property="components:SelectTextOnFocus.Active"
                         Value="False" />
-                <Style.Triggers>
-                    <Trigger Property="IsFocused"
+				<Style.Triggers>
+					<Trigger Property="IsFocused"
                              Value="True">
-                        <Setter Property="Foreground"
+						<Setter Property="Foreground"
                                 Value="Transparent">
-                        </Setter>
-                    </Trigger>
-                </Style.Triggers>
-            </Style>
-            <components:NegateIntConverter x:Key="NegateIntConverter" />
-            <components:KeyStringConverter x:Key="KeyStringConverter" />
-        </Grid.Resources>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <Grid VerticalAlignment="Top"
+						</Setter>
+					</Trigger>
+				</Style.Triggers>
+			</Style>
+			<components:NegateIntConverter x:Key="NegateIntConverter" />
+			<components:KeyStringConverter x:Key="KeyStringConverter" />
+		</Grid.Resources>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="Auto" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid VerticalAlignment="Top"
               Grid.Row="0"
               Grid.ColumnSpan="2"
               Grid.Column="0">
-            <Rectangle Fill="#FF0F0F0F"
+			<Rectangle Fill="#FF0F0F0F"
                        Stroke="#FF646464" />
-            <DockPanel>
-                <Image HorizontalAlignment="Left"
+			<DockPanel>
+				<Image HorizontalAlignment="Left"
                        VerticalAlignment="Center"
                        Width="26"
                        DockPanel.Dock="Left"
                        Margin="2,0,5,1"
                        Source="../Resources/WFLogo.png" />
-                <Label MouseLeftButtonDown="Hide"
+				<Label MouseLeftButtonDown="Hide"
                        Content="x"
                        Width="30"
                        Style="{StaticResource Label_Button}"
                        VerticalContentAlignment="Stretch"
                        DockPanel.Dock="Right" />
-                <TextBlock Text="Settings"
+				<TextBlock Text="Settings"
                            VerticalAlignment="Center"
                            FontSize="16"
                            FontFamily="{StaticResource Roboto_Black}"
                            FontWeight="Bold" />
-            </DockPanel>
-        </Grid>
-        <ScrollViewer Grid.Row="1"
+			</DockPanel>
+		</Grid>
+		<ScrollViewer Grid.Row="1"
                       Grid.Column="0">
-            <StackPanel Orientation="Vertical">
-                <Border DockPanel.Dock="Top">
-                    <DockPanel>
-                        <Grid DockPanel.Dock="Bottom"
+			<StackPanel Orientation="Vertical">
+				<Border DockPanel.Dock="Top">
+					<DockPanel>
+						<Grid DockPanel.Dock="Bottom"
                               HorizontalAlignment="Stretch">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <RadioButton x:Name="WindowRadio"
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition />
+								<ColumnDefinition Width="Auto" />
+							</Grid.ColumnDefinitions>
+							<RadioButton x:Name="WindowRadio"
                                          Grid.Column="1"
                                          Content="Window"
                                          ToolTip="Display rewards in a separate window"
@@ -150,7 +150,7 @@
                                          Background="#FFB1D0D9"
                                          BorderBrush="#FF0F0F0F"
                                          HorizontalAlignment="Center" />
-                            <RadioButton x:Name="OverlayRadio"
+							<RadioButton x:Name="OverlayRadio"
                                          Grid.Column="2"
                                          Content="Overlay"
                                          ToolTip="Display rewards on top of Warframe"
@@ -158,7 +158,7 @@
                                          Checked="OverlayChecked"
                                          Background="#FFB1D0D9"
                                          BorderBrush="#FF0F0F0F" />
-                            <RadioButton x:Name="LightRadio"
+							<RadioButton x:Name="LightRadio"
                                          Grid.Column="0"
                                          Content="Light"
                                          ToolTip="Do not display any window at all"
@@ -166,48 +166,48 @@
                                          Checked="LightRadioChecked"
                                          Background="#FFB1D0D9"
                                          BorderBrush="#FF0F0F0F" />
-                        </Grid>
-                        <Label Content="Rewards display"
+						</Grid>
+						<Label Content="Rewards display"
                                DockPanel.Dock="Top"
                                HorizontalAlignment="Center"
                                FontFamily="{StaticResource Roboto}"
                                Margin="0,0,-1,0" />
-                    </DockPanel>
-                </Border>
-                <Border DockPanel.Dock="Top">
-                    <UniformGrid>
-                        <Label Content="Display time" />
-                        <TextBox x:Name="Displaytime_number_box"
+					</DockPanel>
+				</Border>
+				<Border DockPanel.Dock="Top">
+					<UniformGrid>
+						<Label Content="Display time" />
+						<TextBox x:Name="Displaytime_number_box"
                                  ToolTip="The time in milliseconds the overlays will be displayed on screen"
                                  Text="{Binding SettingsViewModel.Delay, Mode=TwoWay}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.,]+$" />
 
-                        <CheckBox x:Name="HighlightCheckbox"
+						<CheckBox x:Name="HighlightCheckbox"
                                   Content="Highlight"
                                   ToolTip="Highlight the best rewards on the overlay."
                                   IsChecked="{Binding SettingsViewModel.HighlightRewards, Mode=TwoWay}" />
-                        <CheckBox x:Name="HighContrastCheckbox"
+						<CheckBox x:Name="HighContrastCheckbox"
                                   Content="High contrast"
                                   ToolTip="Enable High contrast for the overlay."
                                   IsChecked="{Binding SettingsViewModel.HighContrast, Mode=TwoWay}" />
-                    </UniformGrid>
-                </Border>
-                <Border x:Name="Overlay_sliders"
+					</UniformGrid>
+				</Border>
+				<Border x:Name="Overlay_sliders"
                         DockPanel.Dock="Top">
-                    <DockPanel LastChildFill="False">
-                        <Label Content="Overlay Offset"
+					<DockPanel LastChildFill="False">
+						<Label Content="Overlay Offset"
                                DockPanel.Dock="Top"
                                HorizontalAlignment="Center"
                                FontFamily="{StaticResource Roboto}"
                                Margin="0,0,-1,0" />
-                        <DockPanel LastChildFill="False"
+						<DockPanel LastChildFill="False"
                                    DockPanel.Dock="Top">
-                            <Label Content="X"
+							<Label Content="X"
                                    DockPanel.Dock="Left"
                                    HorizontalContentAlignment="Center"
                                    Width="32"
                                    ToolTip="The X Offset of the overlay. Positive values shift the overlay to the right." />
-                            <TextBox x:Name="OverlayXOffset_number_box"
+							<TextBox x:Name="OverlayXOffset_number_box"
                                      DockPanel.Dock="Left"
                                      ToolTip="The X Offset of the overlay. Positive values shift the overlay to the right."
                                      TextWrapping="Wrap"
@@ -215,60 +215,60 @@
                                      components:NumericOnlyEntry.RegexFilter="^-?[0-9]*$"
                                      Width="90" />
 
-                            <TextBox x:Name="OverlayYOffset_number_box"
+							<TextBox x:Name="OverlayYOffset_number_box"
                                      DockPanel.Dock="Right"
                                      ToolTip="The Y Offset of the overlay. Positive values shift the overlay towards the top."
                                      Width="90"
                                      Text="{Binding SettingsViewModel.OverlayYOffsetValue, Mode=TwoWay
                              , Converter={StaticResource NegateIntConverter}}"
                                      components:NumericOnlyEntry.RegexFilter="^-?[0-9]*$" />
-                            <Label Content="Y"
+							<Label Content="Y"
                                    DockPanel.Dock="Right"
                                    HorizontalContentAlignment="Center"
                                    Width="32"
                                    ToolTip="The Y Offset of the overlay. Positive values shift the overlay towards the top." />
-                        </DockPanel>
-                    </DockPanel>
-                </Border>
-                <Border DockPanel.Dock="Top">
-                    <UniformGrid>
-                        <Label Content="Snap Noise"
+						</DockPanel>
+					</DockPanel>
+				</Border>
+				<Border DockPanel.Dock="Top">
+					<UniformGrid>
+						<Label Content="Snap Noise"
                                ToolTip="Snap-It item count noise filtering threshhold" />
-                        <TextBox x:Name="SnapItCountThreshold_number_box"
+						<TextBox x:Name="SnapItCountThreshold_number_box"
                                  ToolTip="Threshold for number detection noise filtering. Higher = More aggressive, 3 or 4 usually works best"
                                  Text="{Binding SettingsViewModel.SnapItCountThreshold, Mode=TwoWay}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.,]+$"
                                  VerticalAlignment="Top" />
 
-                        <CheckBox x:Name="SnapItemCountCheckbox"
+						<CheckBox x:Name="SnapItemCountCheckbox"
                                   Content="Count Item"
                                   ToolTip="Scan for item amount using Snap-It"
                                   IsChecked="{Binding SettingsViewModel.DoSnapItCount, Mode=TwoWay}" />
 
-                        <CheckBox x:Name="SnapItThreadCheckbox"
+						<CheckBox x:Name="SnapItThreadCheckbox"
                                   Content="Multithread Snap"
                                   ToolTip="Speed up snap-it using multithreading"
                                   IsChecked="{Binding SettingsViewModel.SnapMultiThreaded, Mode=TwoWay}" />
 
-                    </UniformGrid>
-                </Border>
-                <Border DockPanel.Dock="Top"
+					</UniformGrid>
+				</Border>
+				<Border DockPanel.Dock="Top"
                         Padding="15 5 25 5">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition />
-                            <ColumnDefinition />
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition />
-                            <RowDefinition />
-                            <RowDefinition />
-                            <RowDefinition />
-                        </Grid.RowDefinitions>
-                        <Label Content="Activation key"
+					<Grid>
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition />
+							<ColumnDefinition />
+						</Grid.ColumnDefinitions>
+						<Grid.RowDefinitions>
+							<RowDefinition />
+							<RowDefinition />
+							<RowDefinition />
+							<RowDefinition />
+						</Grid.RowDefinitions>
+						<Label Content="Activation key"
                                Grid.Row="0"
                                Grid.Column="0" />
-                        <TextBox x:Name="Activation_key_box"
+						<TextBox x:Name="Activation_key_box"
                                  Style="{StaticResource KeyBindTextboxStyle}"
                                  Grid.Row="0"
                                  Grid.Column="1"
@@ -277,7 +277,7 @@
                                  IsReadOnly="True"
                                  KeyUp="ActivationUp"
                                  VerticalAlignment="Top" />
-                        <TextBlock x:Name="hidden"
+						<TextBlock x:Name="hidden"
                                    Focusable="True"
                                    Visibility="Visible"
                                    IsEnabled="True"
@@ -289,10 +289,10 @@
                                    Width="1"
                                    RenderTransformOrigin="0.5,0.5"
                                    d:IsHidden="True" />
-                        <Label Content="Search it modifier"
+						<Label Content="Search it modifier"
                                Grid.Row="1"
                                Grid.Column="0" />
-                        <TextBox x:Name="Searchit_key_box"
+						<TextBox x:Name="Searchit_key_box"
                                  Style="{StaticResource KeyBindTextboxStyle}"
                                  Grid.Row="1"
                                  Grid.Column="1"
@@ -302,10 +302,10 @@
                                  Text="{Binding SettingsViewModel.SearchItModifierKey,
                                 Converter={StaticResource KeyStringConverter}}"
                                  VerticalAlignment="Top" />
-                        <Label Content="Snap it modifier"
+						<Label Content="Snap it modifier"
                                Grid.Row="2"
                                Grid.Column="0" />
-                        <TextBox x:Name="Snapit_key_box"
+						<TextBox x:Name="Snapit_key_box"
                                  Style="{StaticResource KeyBindTextboxStyle}"
                                  Grid.Row="2"
                                  Grid.Column="1"
@@ -315,10 +315,10 @@
                                  KeyUp="Snapit_key_box_KeyUp"
                                  IsReadOnly="True"
                                  VerticalAlignment="Top" />
-                        <Label Content="Master it modifier"
+						<Label Content="Master it modifier"
                                Grid.Row="3"
                                Grid.Column="0" />
-                        <TextBox x:Name="Masterit_key_box"
+						<TextBox x:Name="Masterit_key_box"
                                  Style="{StaticResource KeyBindTextboxStyle}"
                                  Grid.Row="3"
                                  Grid.Column="1"
@@ -328,45 +328,45 @@
                                  IsReadOnly="True"
                                  KeyUp="Masterit_key_box_KeyUp"
                                  VerticalAlignment="Top" />
-                    </Grid>
-                </Border>
-                <Border DockPanel.Dock="Top"
+					</Grid>
+				</Border>
+				<Border DockPanel.Dock="Top"
                         Width="334">
-                    <UniformGrid>
-                        <Label Content="Efficiency min" />
-                        <Label Content="Efficiency max" />
-                        <TextBox ToolTip="Anything below this efficiency will be marked as red in snapit"
+					<UniformGrid>
+						<Label Content="Efficiency min" />
+						<Label Content="Efficiency max" />
+						<TextBox ToolTip="Anything below this efficiency will be marked as red in snapit"
                                  Margin="0, 0, 20, 0"
                                  Text="{Binding SettingsViewModel.MinimumEfficiencyValue, Mode=TwoWay}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.,]+$"
                                  AutoWordSelection="True"
                                  VerticalAlignment="Top" />
-                        <TextBox ToolTip="Anything above this efficiency will be marked as green in snapit"
+						<TextBox ToolTip="Anything above this efficiency will be marked as green in snapit"
                                  Text="{Binding SettingsViewModel.MaximumEfficiencyValue, Mode=TwoWay}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.,]+$"
                                  Margin="0, 0, 20, 0"
                                  VerticalAlignment="Top" />
-                    </UniformGrid>
-                </Border>
-                <Border Padding="0"
+					</UniformGrid>
+				</Border>
+				<Border Padding="0"
                         DockPanel.Dock="Top">
-                    <DockPanel>
-                        <Label MouseLeftButtonDown="ClickCreateDebug"
+					<DockPanel>
+						<Label MouseLeftButtonDown="ClickCreateDebug"
                                Padding="5"
                                DockPanel.Dock="Right"
                                Content="Create debug zip"
                                FontWeight="Regular"
                                Style="{StaticResource Label_Button}" />
-                        <Border Style="{StaticResource NestedBorder}"
+						<Border Style="{StaticResource NestedBorder}"
                                 DockPanel.Dock="Top">
-                            <UniformGrid DockPanel.Dock="Top"
+							<UniformGrid DockPanel.Dock="Top"
                                          Rows="1">
 
-                                <Label Content="Locale"
+								<Label Content="Locale"
                                        DockPanel.Dock="Left"
                                        FontSize="16"
                                        FontWeight="Regular" />
-                                <ComboBox SelectionChanged="localeComboboxSelectionChanged"
+								<ComboBox SelectionChanged="localeComboboxSelectionChanged"
                                           DockPanel.Dock="Right"
                                           x:Name="localeCombobox"
                                           FontSize="14"
@@ -374,43 +374,47 @@
                                           Background="#FF1B1B1B"
                                           BorderBrush="#FF0F0F0F"
                                           Margin="0,4" Template="{DynamicResource ComboBoxTemplate}" Style="{DynamicResource ComboBoxStyle1}">
-                                    <ComboBoxItem Tag="en"
+									<ComboBoxItem Tag="en"
                                                   Content="English"
                                                   FontSize="14"
                                                   Background="#FF1B1B1B" />
-                                    <ComboBoxItem Tag="ko"
+									<ComboBoxItem Tag="ko"
                                                   Content="한국어"
                                                   FontSize="14"
                                                   Background="#FF1B1B1B" />
-                                </ComboBox>
-                            </UniformGrid>
-                        </Border>
-                        <Border DockPanel.Dock="Top"
+									<ComboBoxItem Tag="ru"
+                                                  Content="Russian"
+                                                  FontSize="14"
+                                                  Background="#FF1B1B1B" />
+								</ComboBox>
+							</UniformGrid>
+						</Border>
+						<Border DockPanel.Dock="Top"
                                 Style="{StaticResource NestedBorder}">
-                            <CheckBox x:Name="clipboardCheckbox"
+							<CheckBox x:Name="clipboardCheckbox"
                                       Content="Clipboard"
                                       ToolTip="Copy the results from the OCR over to the clipboard for easy pasting into chat"
                                       IsChecked="{Binding SettingsViewModel.Clipboard, Mode=TwoWay}" />
-                        </Border>
-                        <Border DockPanel.Dock="Top"
+						</Border>
+						<Border DockPanel.Dock="Top"
                                 Style="{StaticResource NestedBorder}">
-                            <UniformGrid Rows="1">
+							<UniformGrid Rows="1">
 
-                                <CheckBox x:Name="autoCheckbox"
+								<CheckBox x:Name="autoCheckbox"
                                           DockPanel.Dock="Right"
                                           Content="Auto"
                                           ToolTip="Automatically detects when the relic screen is visible."
                                           Click="AutoClicked" />
-                                <CheckBox x:Name="Autolist"
+								<CheckBox x:Name="Autolist"
                                           DockPanel.Dock="Left"
                                           Content="Auto list"
                                           ToolTip="Spawns a listing dialogue whenever the end of mission is detected, requires auto"
                                           IsChecked="{Binding SettingsViewModel.AutoList, Mode=TwoWay}" />
-                            </UniformGrid>
-                        </Border>
-                    </DockPanel>
-                </Border>
-            </StackPanel>
-        </ScrollViewer>
-    </Grid>
+							</UniformGrid>
+						</Border>
+					</DockPanel>
+				</Border>
+			</StackPanel>
+		</ScrollViewer>
+	</Grid>
 </Window>


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
Added russian lang recognition, also slightly altered method that was finding eng -> other language translation to compare names correctly

### Evidence/screenshot/link to line

I posted a screenshot on discord

### Considerations
I specified that minimum number of characters in the name of the item is 16, but I'm not so sure about that. Didn't find anything shorter tho.
Also eng -> other language method was working weird and wasn't showing all names which broke some items recognition so I changed it a little, but korean version also uses it. I don't think It broke something on their end since It's not locale specific.