### PR TITLE
docs: make snap-it more consistently named in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -161,7 +161,7 @@
                             <li><a href="#" data-tab="tab-1" class="active">Display mode</a></li>
                             <li><a href="#" data-tab="tab-2">Overlay options</a></li>
                             <li><a href="#" data-tab="tab-3">Activation hotkeys</a></li>
-                            <li><a href="#" data-tab="tab-4">Snap it efficiency</a></li>
+                            <li><a href="#" data-tab="tab-4">Snap-it efficiency</a></li>
                             <li><a href="#" data-tab="tab-5">Miscellaneous</a></li>
                         </ul>
                         <div class="tabs">
@@ -211,7 +211,7 @@
                                         <img src="images/WFInfo_2020-07-04_01-35-18.png" alt="" style="max-width:600px; margin-left: auto; margin-right: auto"/>
                                     </div>
                                     <p class="caption">
-                                        Snap it efficiency, these are ducats per plat values. Anything under the min value will display as red and anything above the max value will display as green.
+                                        Snap-it efficiency, these are ducats per plat values. Anything under the min value will display as red and anything above the max value will display as green.
                                     </p>
                                 </div>
                             </div>
@@ -364,7 +364,7 @@
                         <div class="flex flex-2">
                             <div class="image col">
                                 <p class="caption">
-                                    Added snapit to equipment scaning
+                                    Added snap-it to equipment scaning
                                 </p>
                             </div>
                             <div class="image col">
@@ -713,7 +713,7 @@
           (function() {
             var u="https://stats.warframestat.us/";
             _paq.push(['setTrackerUrl', u+'matomo.php']);
-            _paq.push(['setSiteId', '4']);
+            _paq.push(['setSiteId', '5']);
             var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
             g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
           })();


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
- clean up snap-it references to use the same spelling and punctuation
- also update matomo site (it was set back up a while ago, forgot to give the new id) 

---

### Reproduction steps
open https://wfinfo.warframestat.us

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Docs]**
