### PR TITLE
Proxy support, refactoring, less verbose logs

### DIFF
--- a/WFInfo/CustomEntrypoint.cs
+++ b/WFInfo/CustomEntrypoint.cs
@@ -199,6 +199,17 @@ namespace WFInfo
                 sw.WriteLineAsync("[" + DateTime.UtcNow + " - Still in custom entrypoint]   " + argm);
         }
 
+        public static WebClient createNewWebClient()
+        {
+            WebProxy proxy = null;
+            String proxy_string = Environment.GetEnvironmentVariable("http_proxy");
+            if (proxy_string != null)
+            {
+                proxy = new WebProxy(new Uri(proxy_string));
+            }
+            return new WebClient() { Proxy = proxy };
+        }
+
         public static bool isAVX2Available()
         {
             string dll;
@@ -237,7 +248,7 @@ namespace WFInfo
                 if (!File.Exists(path) || GetMD5hash(path) != md5)
                 {
                     sw.WriteLineAsync("[" + DateTime.UtcNow + "] AVX2 DLL is missing or corrupted, downloading");
-                    WebClient webClient = new WebClient();
+                    WebClient webClient = createNewWebClient();
                     webClient.DownloadFile(libs_hotlink_prefix + "/" + dll, path);
                 }
 
@@ -349,7 +360,7 @@ namespace WFInfo
         public static string GetMD5hashByURL(string url)
         {
             Debug.WriteLine(url);
-            WebClient webClient = new WebClient();
+            WebClient webClient = createNewWebClient();
             using (var md5 = MD5.Create())
             {
                 byte[] stream = webClient.DownloadData(url);
@@ -366,7 +377,7 @@ namespace WFInfo
 
         private static async void RefreshTesseractDlls(CancellationToken token, bool AvxSupport)
         {
-            WebClient webClient = new WebClient();
+            WebClient webClient = createNewWebClient();
             webClient.DownloadProgressChanged += new DownloadProgressChangedEventHandler(DownloadProgressCallback);
             token.Register(webClient.CancelAsync);
 

--- a/WFInfo/Data.cs
+++ b/WFInfo/Data.cs
@@ -83,7 +83,6 @@ namespace WFInfo
             webClient = CustomEntrypoint.createNewWebClient();
             webClient.Headers.Add("platform", "pc");
             webClient.Headers.Add("language", "en");
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
             // Create websocket for WFM
             WebProxy proxy = null;
@@ -1115,7 +1114,6 @@ namespace WFInfo
         {
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
             Main.AddLog("Connecting to websocket");
-            marketSocket.SslConfiguration.EnabledSslProtocols = SslProtocols.Tls12;
 
             if (marketSocket.IsAlive)
             {

--- a/WFInfo/Services/TesseractService.cs
+++ b/WFInfo/Services/TesseractService.cs
@@ -100,7 +100,7 @@ namespace WFInfo
             string traineddata_hotlink = traineddata_hotlink_prefix + Locale + ".traineddata";
             string app_data_traineddata_path = AppdataTessdataFolder + @"\" + Locale + ".traineddata";
 
-            WebClient webClient = new WebClient();
+            WebClient webClient = CustomEntrypoint.createNewWebClient();
 
             if (!File.Exists(app_data_traineddata_path) || CustomEntrypoint.GetMD5hash(app_data_traineddata_path) != traineddata_checksums.GetValue(Locale).ToObject<string>())
             {

--- a/WFInfo/UpdateDialogue.xaml.cs
+++ b/WFInfo/UpdateDialogue.xaml.cs
@@ -32,7 +32,7 @@ namespace WFInfo
             NewVersionText.Text = "WFInfo version " + version + " has been released!";
             OldVersionText.Text = "You have version " + Main.BuildVersion + " installed.";
 
-            WebClient = new WebClient();
+            WebClient = CustomEntrypoint.createNewWebClient();
             WebClient.Headers.Add("platform", "pc");
             WebClient.Headers.Add("language", "en");
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;


### PR DESCRIPTION
* No longer print JWT poll details (every 1 minute). It will now only print when Login happens or in case of errors
* Proxy support that was partially borrowed from #236 . To use proxy set env variable `http_proxy` in Windows settings. Proxy only needed for power users anyway.
* Some code cleanup/refactoring around generic factory for webclient (for any future use)