### PR TITLE
Disable snapit count checks temporarily

### DIFF
--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -866,11 +866,13 @@ namespace WFInfo
                 });
             }
 
-            if (_settings.DoSnapItCount)
-                Main.RunOnUIThread(() =>
-                {
-                    VerifyCount.ShowVerifyCount(foundParts);
-                 });
+            // Temporarily disabled due to UI changes
+            // Requires rewrite
+            //if (_settings.DoSnapItCount)
+            //    Main.RunOnUIThread(() =>
+            //    {
+            //        VerifyCount.ShowVerifyCount(foundParts);
+            //     });
 
             if (Main.snapItOverlayWindow.tempImage != null)
                 Main.snapItOverlayWindow.tempImage.Dispose();
@@ -1173,10 +1175,12 @@ namespace WFInfo
                 results.Add(new InventoryItem(name, itemGroup.Item2));
             }
 
-            if ( _settings.DoSnapItCount)
-            {
-                GetItemCounts(filteredImage, filteredImageClean, results, font, _settings.SnapItCountThreshold);
-            }
+            // Temporarily disabled due to UI changes
+            // Requires rewrite
+            //if ( _settings.DoSnapItCount)
+            //{
+            //    GetItemCounts(filteredImage, filteredImageClean, results, font, _settings.SnapItCountThreshold);
+           // }
 
             filteredImageClean.Dispose();
             red.Dispose();

--- a/WFInfo/Settings/SettingsWindow.xaml
+++ b/WFInfo/Settings/SettingsWindow.xaml
@@ -243,7 +243,7 @@
                         <CheckBox x:Name="SnapItemCountCheckbox"
                                   Content="Count Item"
                                   ToolTip="Scan for item amount using Snap-It"
-                                  IsChecked="{Binding SettingsViewModel.DoSnapItCount, Mode=TwoWay}" />
+                                  IsChecked="{Binding SettingsViewModel.DoSnapItCount, Mode=TwoWay}" IsEnabled="false"  />
 
                         <CheckBox x:Name="SnapItThreadCheckbox"
                                   Content="Multithread Snap"


### PR DESCRIPTION
Disable snapit count feature because discord is countless crash screens.
Feature doesn't work so will be rewritten in the future.