### PR TITLE
Snapit item counting rewrite, Separate snap-it display time

### DIFF
--- a/WFInfo/Data.cs
+++ b/WFInfo/Data.cs
@@ -98,7 +98,10 @@ namespace WFInfo
             {
                 Proxy = proxy
             };
+            handler.UseCookies = false;
             client = new HttpClient(handler);
+
+            marketSocket.SslConfiguration.EnabledSslProtocols = SslProtocols.None;
         }
 
         public void EnableLogCapture()

--- a/WFInfo/Data.cs
+++ b/WFInfo/Data.cs
@@ -166,7 +166,13 @@ namespace WFInfo
             {
                 string name = item["item_name"].ToString();
                 if (name.Contains("Prime "))
+                {
+                    if ((name.Contains("Neuroptics") || name.Contains("Chassis") || name.Contains("Systems") || name.Contains("Harness") || name.Contains("Wings")))
+                    {
+                        name = name.Replace(" Blueprint", "");
+                    }
                     marketItems[item["id"].ToString()] = name + "|" + item["url_name"];
+                }
             }
 
             try
@@ -240,22 +246,16 @@ namespace WFInfo
                 string name = row["name"].ToString();
                 if (name.Contains("Prime "))
                 {
+                    if ((name.Contains("Neuroptics") || name.Contains("Chassis") || name.Contains("Systems") || name.Contains("Harness") || name.Contains("Wings")))
+                    {
+                       name = name.Replace(" Blueprint", "");
+                    }
                     marketData[name] = new JObject
                     {
                         {"plat", double.Parse(row["custom_avg"].ToString(), Main.culture)},
                         {"ducats", 0},
                         {"volume", int.Parse(row["yesterday_vol"].ToString(), Main.culture) + int.Parse(row["today_vol"].ToString(), Main.culture)}
                     };
-                    if (!name.EndsWith(" Blueprint"))
-                    {
-                        name += " Blueprint";
-                        marketData[name] = new JObject
-                        {
-                            {"plat", double.Parse(row["custom_avg"].ToString(), Main.culture)},
-                            {"ducats", 0},
-                            {"volume", int.Parse(row["yesterday_vol"].ToString(), Main.culture) + int.Parse(row["today_vol"].ToString(), Main.culture)}
-                        };
-                    }
                 }
             }
 
@@ -282,7 +282,19 @@ namespace WFInfo
             JObject stats =
                 JsonConvert.DeserializeObject<JObject>(
                     webClient.DownloadString("https://api.warframe.market/v1/items/" + url + "/statistics"));
-            stats = stats["payload"]["statistics_closed"]["90days"].Last.ToObject<JObject>();
+            JToken latestStats = stats["payload"]["statistics_closed"]["90days"].LastOrDefault();
+            if (latestStats == null)
+            {
+                stats = new JObject
+                {
+                    { "plat", 999 },
+                    { "volume", 0 }
+                };
+            } 
+            else
+            {
+                stats = latestStats.ToObject<JObject>();
+            }
 
             Thread.Sleep(333);
             webClient = createWfmClient();

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -804,7 +804,8 @@ namespace WFInfo
             watch.Start();
             long start = watch.ElapsedMilliseconds;
 
-            timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH-mm-ssff", Main.culture);
+            //timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH-mm-ssff", Main.culture);
+            string timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH-mm-ssff", Main.culture);
             WFtheme theme = GetThemeWeighted(out _, fullShot);
             snapItImage.Save(Main.AppPath + @"\Debug\SnapItImage " + timestamp + ".png");
             Bitmap snapItImageFiltered = ScaleUpAndFilter(snapItImage, theme, out int[] rowHits, out int[] colHits);

--- a/WFInfo/Settings/ApplicationSettings.cs
+++ b/WFInfo/Settings/ApplicationSettings.cs
@@ -71,9 +71,7 @@ namespace WFInfo.Settings
         public double MaximumEfficiencyValue { get; set; } = 9.5;
         public double MinimumEfficiencyValue { get; set; } = 4.5;
         public bool DoSnapItCount { get; set; } = false;
-        public int SnapItCountThreshold { get; set; } = 4;
-        public int SnapItEdgeWidth { get; set; } = 1;
-        public int SnapItEdgeRadius { get; set; } = 1;
+        public int SnapItDelay { get; set; } = 20000;
         public double SnapItHorizontalNameMargin { get; set; } = 0;
         public bool DoCustomNumberBoxWidth { get; set; } = false;
         public double SnapItNumberBoxWidth { get; set; } = 0.4;

--- a/WFInfo/Settings/IReadOnlyApplicationSettings.cs
+++ b/WFInfo/Settings/IReadOnlyApplicationSettings.cs
@@ -46,9 +46,7 @@ namespace WFInfo.Settings
         double MaximumEfficiencyValue { get; }
         double MinimumEfficiencyValue { get; }
         bool DoSnapItCount { get; }
-        int SnapItCountThreshold { get; }
-        int SnapItEdgeWidth { get; }
-        int SnapItEdgeRadius { get; }
+        int SnapItDelay { get; }
         double SnapItHorizontalNameMargin { get; }
         bool DoCustomNumberBoxWidth { get; }
         double SnapItNumberBoxWidth { get; }

--- a/WFInfo/Settings/SettingsViewModel.cs
+++ b/WFInfo/Settings/SettingsViewModel.cs
@@ -296,29 +296,11 @@ namespace WFInfo.Settings
             }
         }
 
-        public int SnapItCountThreshold
+        public int SnapItDelay
         {
-            get => _settings.SnapItCountThreshold;
+            get => _settings.SnapItDelay;
             set { 
-                _settings.SnapItCountThreshold = value;
-                RaisePropertyChanged(); 
-            }
-        }
-
-        public int SnapItEdgeWidth
-        {
-            get => _settings.SnapItEdgeWidth;
-            set { 
-                _settings.SnapItEdgeWidth = value;
-                RaisePropertyChanged(); 
-            }
-        }
-
-        public int SnapItEdgeRadius
-        {
-            get => _settings.SnapItEdgeRadius;
-            set { 
-                _settings.SnapItEdgeRadius = value;
+                _settings.SnapItDelay = value;
                 RaisePropertyChanged(); 
             }
         }

--- a/WFInfo/Settings/SettingsWindow.xaml
+++ b/WFInfo/Settings/SettingsWindow.xaml
@@ -132,7 +132,8 @@
         <ScrollViewer Grid.Row="1"
                       Grid.Column="0">
             <StackPanel Orientation="Vertical">
-                <Border DockPanel.Dock="Top">
+                <Border DockPanel.Dock="Top"
+                        Padding="15 5 25 5">
                     <DockPanel>
                         <Grid DockPanel.Dock="Bottom"
                               HorizontalAlignment="Stretch">
@@ -174,7 +175,8 @@
                                Margin="0,0,-1,0" />
                     </DockPanel>
                 </Border>
-                <Border DockPanel.Dock="Top">
+                <Border DockPanel.Dock="Top"
+                        Padding="15 5 25 5">
                     <UniformGrid>
                         <Label Content="Display time" />
                         <TextBox x:Name="Displaytime_number_box"
@@ -193,7 +195,8 @@
                     </UniformGrid>
                 </Border>
                 <Border x:Name="Overlay_sliders"
-                        DockPanel.Dock="Top">
+                        DockPanel.Dock="Top"
+                        Padding="15 5 25 5">
                     <DockPanel LastChildFill="False">
                         <Label Content="Overlay Offset"
                                DockPanel.Dock="Top"
@@ -230,20 +233,20 @@
                         </DockPanel>
                     </DockPanel>
                 </Border>
-                <Border DockPanel.Dock="Top">
+                <Border DockPanel.Dock="Top" 
+                        Padding="15 5 25 5">
                     <UniformGrid>
-                        <Label Content="Snap Noise"
-                               ToolTip="Snap-It item count noise filtering threshhold" />
-                        <TextBox x:Name="SnapItCountThreshold_number_box"
-                                 ToolTip="Threshold for number detection noise filtering. Higher = More aggressive, 3 or 4 usually works best"
-                                 Text="{Binding SettingsViewModel.SnapItCountThreshold, Mode=TwoWay}"
+                        <Label Content="Display time (snap)"/>
+                        <TextBox x:Name="SnapItDisplaytime_number_box"
+                                 ToolTip="The time in milliseconds the overlays will be displayed on screen"
+                                 Text="{Binding SettingsViewModel.SnapItDelay, Mode=TwoWay}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.,]+$"
                                  VerticalAlignment="Top" />
 
                         <CheckBox x:Name="SnapItemCountCheckbox"
                                   Content="Count Item"
                                   ToolTip="Scan for item amount using Snap-It"
-                                  IsChecked="{Binding SettingsViewModel.DoSnapItCount, Mode=TwoWay}" IsEnabled="false"  />
+                                  IsChecked="{Binding SettingsViewModel.DoSnapItCount, Mode=TwoWay}" />
 
                         <CheckBox x:Name="SnapItThreadCheckbox"
                                   Content="Multithread Snap"
@@ -331,7 +334,8 @@
                     </Grid>
                 </Border>
                 <Border DockPanel.Dock="Top"
-                        Width="334">
+                        Width="334"
+                        Padding="15 5 25 5">
                     <UniformGrid>
                         <Label Content="Efficiency min" />
                         <Label Content="Efficiency max" />


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
(built on top of #249)
- Rewrote most of the core logic for snap-it item counting to accomodate the UI changes that happened in [update 31.1.0](https://forums.warframe.com/topic/1299619-update-3110-echoes-of-war/)
- Add separate display time setting for snap-it (reusing the now-deprecated snap noise UI elements)
- Removed settings deprecated by the snap-it item counting rewrite


---

### Reproduction steps (separate display time) 
1. Use snap-it
2. Start timer when first result pops in
3. Stop timer when first result pops out
4. Check if it follows the `Display Time` setting or the `Display Time (snap)` setting *(note: setting changes seem to only save once you move selection to a different setting, or toggle a checkbox or radio button)* 

---

### Evidence/screenshot/link to line

Setting changes can be seen in the various settings subfolders, along with the line within OCR.cs where the snap-it popup is created

The snap-it item counting rewrite is primarily contained within the GetItemCounts function, with some minor changes elsewhere in the file to accomodate new data needs (mainly unfiltered version of the image). It may be preferrable to read the new version of the file [starting here](https://github.com/D1firehail/WFinfo/blob/efbeb4e5b8f297dcbfefc2147c36ac63de9132e0/WFInfo/Ocr.cs#L1305) and [ending here](https://github.com/D1firehail/WFinfo/blob/efbeb4e5b8f297dcbfefc2147c36ac63de9132e0/WFInfo/Ocr.cs#L1576). Comments should explain what block of code does each step, but the algorithm goes roughly as follows
1. Get center of mass for the black pixels within the area. Unless there's extremely high levels of noise within the zone, that should be within the checkmark+circle icon (or very close to it)
2. From that center of mass, search outward along the x and y axis until you find a black pixel, this should be the icon
3. Do a "flood fill search" (with some margin for the rare gap), calculating a new center of mass for just the icon as you go
4. From that center of mass, find the background colour for the item count label by going in a diagonal line toward the top-left and bottom-right, remembering any time there's "main" pixel and the one to each side of it are the same colour. The most common colour found in this process should be the background colour
5. From the (second pass) center of mass, go diagonally top-right (along the larger arm of the checkmark) until you reach the background colour, from that point follow the colour to find the whole item count label
6. Feed your newly found area into the OCR. cutting away the checkmark+circle is unnecessary as it seems to reliably be either not read or read as a 0, neither of which affect the outcome.

If the total amount of black pixels in either of the center of mass calculations is too low, the background colour can't be identified or the total height or width is too small, assume there's no item amount label and move on (amount detected for items default to 1, as there won't be a label then)

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix/Feature/Maintenance]**
