### PR TITLE
Only running search after input is finished

### DIFF
--- a/WFInfo/EquipmentWindow.cs
+++ b/WFInfo/EquipmentWindow.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Forms;
 
 namespace WFInfo
 {
@@ -16,6 +17,8 @@ namespace WFInfo
         private Dictionary<string, TreeNode> primeTypes;
         private bool searchActive = false;
         private bool showAllEqmt = false;
+        private int searchTimerDurationMS = 500;
+        public static Timer searchTimer = new Timer();
         public static string[] searchText;
         public static EquipmentWindow INSTANCE;
 
@@ -32,7 +35,8 @@ namespace WFInfo
 
         public void reloadItems()
         {
-            if (primeTypes != null) {
+            if (primeTypes != null)
+            {
                 foreach (TreeNode category in primeTypes.Values)
                 {
                     foreach (TreeNode prime in category.Children)
@@ -201,6 +205,28 @@ namespace WFInfo
                 ReapplyFilters();
         }
 
+        /// <summary>
+        /// Starts a timer to wait to apply changes to filters on search bar
+        /// </summary>
+        private void StartSearchReapplyTimer()
+        {
+            if (searchTimer.Enabled)
+            {
+                searchTimer.Stop();
+                Main.AddLog("Stopped timer through change");
+            }
+
+            searchTimer.Interval = searchTimerDurationMS;
+            searchTimer.Enabled = true;
+            searchTimer.Tick += (s, e) =>
+            {
+                searchTimer.Enabled = false;
+                searchTimer.Stop();
+                Console.WriteLine("Stopped timer naturally");
+                ReapplyFilters();
+            };
+        }
+
         private void TextboxTextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
         {
             searchActive = textBox.Text.Length > 0 && textBox.Text != "Filter Terms";
@@ -212,7 +238,7 @@ namespace WFInfo
                         searchText = textBox.Text.Split(' ');
                     else
                         searchText = null;
-                    ReapplyFilters();
+                    StartSearchReapplyTimer();
                 }
             }
         }
@@ -343,6 +369,6 @@ namespace WFInfo
         {
             populate();
         }
-        
+
     }
 }

--- a/WFInfo/EquipmentWindow.cs
+++ b/WFInfo/EquipmentWindow.cs
@@ -213,7 +213,6 @@ namespace WFInfo
             if (searchTimer.Enabled)
             {
                 searchTimer.Stop();
-                Main.AddLog("Stopped timer through change");
             }
 
             searchTimer.Interval = searchTimerDurationMS;
@@ -222,7 +221,6 @@ namespace WFInfo
             {
                 searchTimer.Enabled = false;
                 searchTimer.Stop();
-                Console.WriteLine("Stopped timer naturally");
                 ReapplyFilters();
             };
         }

--- a/WFInfo/RelicsViewModel.cs
+++ b/WFInfo/RelicsViewModel.cs
@@ -35,7 +35,6 @@ namespace WFInfo
             if (searchTimer.Enabled)
             {
                 searchTimer.Stop();
-                Main.AddLog("Stopped timer through change");
             }
 
             searchTimer.Interval = searchTimerDurationMS;
@@ -44,7 +43,6 @@ namespace WFInfo
             {
                 searchTimer.Enabled = false;
                 searchTimer.Stop();
-                Main.AddLog("Stopped timer though timer finishing naturally");
                 ReapplyFilters();
             };
         }

--- a/WFInfo/RelicsViewModel.cs
+++ b/WFInfo/RelicsViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Windows.Data;
+using System.Windows.Forms;
 using Newtonsoft.Json.Linq;
 using WebSocketSharp;
 
@@ -20,11 +21,33 @@ namespace WFInfo
 
         private bool _initialized = false;
         private string _filterText = "";
+        private int searchTimerDurationMS = 500;
         private bool _showAllRelics;
         private readonly List<TreeNode> _relicTreeItems;
         private int _sortBoxSelectedIndex;
         private bool _hideVaulted = true;
         private readonly List<TreeNode> _rawRelicNodes = new List<TreeNode>();
+
+        public static Timer searchTimer = new Timer();
+
+        private void StartSearchReapplyTimer()
+        {
+            if (searchTimer.Enabled)
+            {
+                searchTimer.Stop();
+                Main.AddLog("Stopped timer through change");
+            }
+
+            searchTimer.Interval = searchTimerDurationMS;
+            searchTimer.Enabled = true;
+            searchTimer.Tick += (s, e) =>
+            {
+                searchTimer.Enabled = false;
+                searchTimer.Stop();
+                Main.AddLog("Stopped timer though timer finishing naturally");
+                ReapplyFilters();
+            };
+        }
 
         public string FilterText
         {
@@ -32,7 +55,7 @@ namespace WFInfo
             set
             {
                 this.SetField(ref _filterText, value);
-                ReapplyFilters();
+                StartSearchReapplyTimer();
                 RaisePropertyChanged(nameof(IsFilterEmpty));
             }
         }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Hard-coded a .5s (configurable) buffer in between the last change to the search and the final load, so that we weren't regenerating the search every single time.

"One is that some people were requesting searches in the various windows to only take effect when you press enter or similar, since the constant updates cause a fair bit of lag. "
---

### Reproduction steps
<!--
1. Search up something in relics or in equipment tab
2. Notice how the search only populates after you're finished typing (specifically, .5s after last keystroke in the textbox)
-->

---

### Evidence/screenshot/link to line
https://gyazo.com/804e83bc2e6b2378afd819d5b89a46ab for gif of usage


### Considerations
- Does this contain a new dependency? **[No, but we are using a new library.]** In order to smoothly include for the situations in which multiple letters are being changed within the .5 second SLA, we are using a different timing class. Instead of using Windows.Threading.Timer, we are using Windows.Systems.Forms (https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.timer?view=windowsdesktop-7.0) instead. This class is easier and cleaner to have the timer be interrupted without spawning multiple unnecessary threads.
- https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.timer?view=windowsdesktop-7.0
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix/Enhancement]**
