### PR TITLE
Various features related to reward choice, some other fixes

### DIFF
--- a/WFInfo/AutoAddViewModel.cs
+++ b/WFInfo/AutoAddViewModel.cs
@@ -1,0 +1,138 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace WFInfo
+{
+    public class AutoAddViewModel : INPC
+    {
+        private ObservableCollection<AutoAddSingleItem> _itemList;
+
+        public  ObservableCollection<AutoAddSingleItem> ItemList
+        {
+            get => _itemList;
+            private set
+            {
+                _itemList = value;
+                RaisePropertyChanged();
+            }
+        }
+        public AutoAddViewModel()
+        {
+            _itemList = new ObservableCollection<AutoAddSingleItem>();
+        }
+
+        public void addItem(AutoAddSingleItem item)
+        {
+            _itemList.Add(item);
+            RaisePropertyChanged();
+        }
+
+        public void removeItem(AutoAddSingleItem item)
+        {
+            _itemList.Remove(item);
+            RaisePropertyChanged();
+        }
+    }
+
+    public class AutoAddSingleItem : INPC
+    {
+        public AutoAddViewModel _parent;
+
+        private ObservableCollection<string> _rewardOptions;
+
+        public ObservableCollection<string> RewardOptions
+        {
+            get => _rewardOptions;
+            private set
+            {
+                _rewardOptions = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        private string _activeOption;
+        public string ActiveOption
+        {
+            get => _activeOption;
+            set
+            {
+                _activeOption = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public SimpleCommand Increment { get; }
+
+        public SimpleCommand Remove { get; }
+
+        public AutoAddSingleItem(List<string> options, int activeIndex, AutoAddViewModel parent)
+        {
+
+            RewardOptions = new ObservableCollection<string>(options);
+            activeIndex = Math.Min(RewardOptions.Count - 1, activeIndex);
+            if (activeIndex >= 0 && options != null)
+            {
+                ActiveOption = options[activeIndex];
+            } else
+            {
+                ActiveOption = "";
+            }
+            _parent = parent;
+            Remove = new SimpleCommand(() => RemoveFromParent());
+            Increment = new SimpleCommand(() => AddCount(true));
+        }
+
+        public void AddCount(bool save)
+        {
+            //get item count, increment, save
+            bool saveFailed = false;
+            string item = ActiveOption;
+            if (item.Contains("Prime"))
+            {
+                string[] nameParts = item.Split(new string[] { "Prime" }, 2, StringSplitOptions.None);
+                string primeName = nameParts[0] + "Prime";
+                string partName = primeName + ((nameParts[1].Length > 10 && !nameParts[1].Contains("Kubrow")) ? nameParts[1].Replace(" Blueprint", "") : nameParts[1]);
+
+
+                Main.AddLog("Incrementing owned amount for part \"" + partName + "\"");
+                try
+                {
+
+                    int count = Main.dataBase.equipmentData[primeName]["parts"][partName]["owned"].ToObject<int>();
+
+                    Main.dataBase.equipmentData[primeName]["parts"][partName]["owned"] = count + 1;
+                }
+                catch (Exception ex)
+                {
+                    Main.AddLog("FAILED to increment owned amount, Name: " + item + ", primeName: " + primeName + ", partName: " + partName + Environment.NewLine + ex.Message);
+                    saveFailed = true;
+                }
+            }
+            if (saveFailed)
+            {
+                //shouldn't need Main.RunOnUIThread since this is already on the UI Thread
+                //adjust for time diff between snap-it finishing and save being pressed, in case of long delay
+                Main.SpawnErrorPopup(DateTime.UtcNow);
+                Main.StatusUpdate("Failed to save one or more item, report to dev", 2);
+            }
+
+            RemoveFromParent();
+            if (save)
+            {
+                Main.dataBase.SaveAllJSONs();
+                EquipmentWindow.INSTANCE.reloadItems();
+            }
+        }
+
+        private void RemoveFromParent()
+        {
+            if (_parent != null)
+            {
+                _parent.removeItem(this);
+            }
+            RaisePropertyChanged();
+        }
+    }
+}

--- a/WFInfo/AutoCount.xaml
+++ b/WFInfo/AutoCount.xaml
@@ -1,0 +1,214 @@
+﻿<Window x:Class="WFInfo.AutoCount"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:wfInfo="clr-namespace:WFInfo"
+        xmlns:components="clr-namespace:WFInfo.Components"
+        mc:Ignorable="d"
+        Title="Theme Adjuster"
+        MaxWidth="400"
+        MinWidth="400"
+        Width="400"
+        Height="634"
+        BorderBrush="#FF707070"
+        WindowStyle="None"
+        FontSize="16"
+        AllowsTransparency="True"
+        DataContext="{Binding RelativeSource={RelativeSource Self}}"
+        ResizeMode="CanResizeWithGrip">
+    <Window.Resources>
+    </Window.Resources>
+    <Grid MouseDown="MouseDown"
+          Background="#FF1B1B1B"
+          MinWidth="334">
+        <Grid.Resources>
+
+            <Style x:Key="NestedBorder"
+                   TargetType="Border">
+                <Setter Property="BorderBrush"
+                        Value="#FF646464" />
+                <Setter Property="Padding"
+                        Value="5, 2" />
+                <Setter Property="BorderThickness"
+                        Value="1" />
+            </Style>
+            <Style TargetType="Border">
+                <Setter Property="BorderBrush"
+                        Value="#FF646464" />
+                <Setter Property="Padding"
+                        Value="25, 5" />
+                <Setter Property="BorderThickness"
+                        Value="1" />
+            </Style>
+            <Style x:Key="AllTextBoxes"
+                   BasedOn="{StaticResource baseStyle}"
+                   TargetType="TextBox">
+                <Setter Property="Background"
+                        Value="#FF0F0F0F" />
+                <Setter Property="BorderBrush"
+                        Value="#FFB1D0D9" />
+                <Setter Property="VerticalContentAlignment"
+                        Value="Center" />
+                <Setter Property="HorizontalContentAlignment"
+                        Value="Center" />
+                <Setter Property="Margin"
+                        Value="0, 5" />
+                <Setter Property="Padding"
+                        Value="0,1,0,2.5" />
+                <Setter Property="Cursor"
+                        Value="Arrow" />
+                <Setter Property="TextWrapping"
+                        Value="Wrap" />
+                <Setter Property="FontFamily"
+                        Value="{StaticResource Roboto}" />
+                <Setter Property="components:SelectTextOnFocus.Active"
+                        Value="True" />
+                <Setter Property="wfInfo:FocusAdvancement.AdvancesByEnterKey"
+                        Value="True" />
+            </Style>
+
+            <Style TargetType="CheckBox"
+                   BasedOn="{StaticResource baseStyle}">
+                <Setter Property="Background"
+                        Value="#FFB1D0D9" />
+                <Setter Property="BorderBrush"
+                        Value="#FF0F0F0F" />
+                <Setter Property="VerticalContentAlignment"
+                        Value="Center" />
+            </Style>
+            <Style BasedOn="{StaticResource AllTextBoxes}"
+                   TargetType="TextBox" />
+            <Style x:Key="KeyBindTextboxStyle"
+                   BasedOn="{StaticResource AllTextBoxes}"
+                   TargetType="TextBox">
+                <Setter Property="components:SelectTextOnFocus.Active"
+                        Value="False" />
+                <Style.Triggers>
+                    <Trigger Property="IsFocused"
+                             Value="True">
+                        <Setter Property="Foreground"
+                                Value="Transparent">
+                        </Setter>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+            <components:NegateIntConverter x:Key="NegateIntConverter" />
+            <components:KeyStringConverter x:Key="KeyStringConverter" />
+        </Grid.Resources>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="30"> </RowDefinition>
+        </Grid.RowDefinitions>
+        <Grid VerticalAlignment="Top"
+              Grid.Row="0"
+              Grid.ColumnSpan="2"
+              Grid.Column="0">
+            <Rectangle Fill="#FF0F0F0F"
+                       Stroke="#FF646464" />
+            <DockPanel>
+                <Image HorizontalAlignment="Left"
+                       VerticalAlignment="Center"
+                       Width="26"
+                       DockPanel.Dock="Left"
+                       Margin="2,0,5,1"
+                       Source="Resources/WFLogo.png" />
+                <Label MouseLeftButtonDown="Hide"
+                       Content="x"
+                       Width="30"
+                       Style="{StaticResource Label_Button}"
+                       VerticalContentAlignment="Stretch"
+                       DockPanel.Dock="Right" />
+                <TextBlock Text="Theme Adjuster"
+                           VerticalAlignment="Center"
+                           FontSize="16"
+                           FontFamily="{StaticResource Roboto_Black}"
+                           FontWeight="Bold" />
+            </DockPanel>
+        </Grid>
+        <ScrollViewer Grid.Row="1">
+            
+        <DataGrid ItemsSource="{Binding viewModel.ItemList}" AutoGenerateColumns="False" Margin="0" VerticalAlignment="Top" HorizontalAlignment="Stretch" HeadersVisibility="Column" PreviewMouseWheel="RedirectScrollToParent">
+            <DataGrid.Resources>
+                <ResourceDictionary>
+                    <Style BasedOn="{StaticResource baseStyle}" TargetType="{x:Type DataGridColumnHeader}">
+                        <Setter Property="Background" Value="#FF1B1B1B" />
+                    </Style>
+                    <Style TargetType="{x:Type DataGridCell}">
+                        <Style.Triggers>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource Self}, Path=Foreground}"/>
+                                <Setter Property="Background" Value="{Binding RelativeSource={RelativeSource Self}, Path=Background}"/>
+                                <Setter Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource Self}, Path=BorderBrush}"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </ResourceDictionary>
+            </DataGrid.Resources>
+            <DataGrid.Columns>
+                    <DataGridTemplateColumn Header=" Items" Width="*">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <ComboBox 
+                                    x:Name="themeSelectionComboBox"
+                                    FontSize="14"
+                                    FontFamily="{DynamicResource Roboto}"
+                                    Background="#FF1B1B1B"
+                                    BorderBrush="#FF0F0F0F"
+                                    HorizontalAlignment="Stretch"
+                                    ItemsSource="{Binding RewardOptions}"
+                                    SelectedItem="{Binding ActiveOption, Mode=TwoWay}"
+                                    Margin="5,3" Template="{DynamicResource ComboBoxTemplate}" Style="{DynamicResource ComboBoxStyle1}">
+                                </ComboBox>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTemplateColumn Header="Save" Width="70">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Label Grid.Column="1" Content="✓" Foreground="#506464" FontSize="14" Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Center"   Style="{StaticResource Label_Button}">
+                                    <Label.InputBindings>
+                                        <MouseBinding MouseAction="LeftClick" Command="{Binding Increment}" />
+                                    </Label.InputBindings>
+                                </Label>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTemplateColumn Header="Dismiss" Width="70">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Label Grid.Column="2" Content="X" Foreground="#506464" FontSize="14" Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Center"   Style="{StaticResource Label_Button}">
+                                    <Label.InputBindings>
+                                        <MouseBinding MouseAction="LeftClick" Command="{Binding Remove}" />
+                                    </Label.InputBindings>
+                                </Label>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                </DataGrid.Columns>
+            </DataGrid>
+        </ScrollViewer>
+        <Grid Grid.Row="2">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition></ColumnDefinition>
+                <ColumnDefinition></ColumnDefinition>
+            </Grid.ColumnDefinitions>
+            <Label Grid.Column="0" Content="Save all" Foreground="#506464" FontSize="14" Style="{StaticResource Label_Button}">
+                <Label.InputBindings>
+                    <MouseBinding MouseAction="LeftClick" Command="{Binding IncrementAll}" />
+                </Label.InputBindings>
+            </Label>
+
+            <Label Grid.Column="1" Content="Dismiss all" Foreground="#506464" FontSize="14" Style="{StaticResource Label_Button}">
+                <Label.InputBindings>
+                    <MouseBinding MouseAction="LeftClick" Command="{Binding RemoveAll}" />
+                </Label.InputBindings>
+            </Label>
+        </Grid>
+        </Grid>
+</Window>

--- a/WFInfo/AutoCount.xaml.cs
+++ b/WFInfo/AutoCount.xaml.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace WFInfo
+{
+    /// <summary>
+    /// Interaction logic for AutoCount.xaml
+    /// </summary>
+    public partial class AutoCount : Window
+    {
+
+        //private readonly Settings.SettingsViewModel _viewModel;
+        //public Settings.SettingsViewModel SettingsViewModel => _viewModel;
+
+        public static AutoCount INSTANCE;
+        public AutoAddViewModel viewModel { get; }
+        public SimpleCommand IncrementAll { get; }
+        public SimpleCommand RemoveAll { get; }
+
+        public AutoCount()
+        {
+            INSTANCE = this;
+            viewModel = new AutoAddViewModel();
+
+            RemoveAll = new SimpleCommand(() => RemoveFromParentAll());
+            IncrementAll = new SimpleCommand(() => AddCountAll());
+
+            for (int i = 0; i < 30; i++)
+            {
+                List<string> tmp = new List<string>();
+                tmp.Add("Ivara Prime Blueprint");
+                tmp.Add("Braton Prime Blueprint");
+                tmp.Add("Paris Prime Upper Limb");
+                AutoAddSingleItem tmpItem = new AutoAddSingleItem(tmp, i % 5, viewModel);
+                viewModel.addItem(tmpItem);
+            }
+            InitializeComponent();
+        }
+        public static void ShowAutoCount()
+        {
+            if (INSTANCE != null)
+            {
+                INSTANCE.Show();
+                INSTANCE.Focus();
+            }
+        }
+
+        private void Hide(object sender, RoutedEventArgs e)
+        {
+            Hide();
+        }
+
+        private void AddCountAll()
+        {
+            foreach (AutoAddSingleItem item in viewModel.ItemList)
+            {
+                if (item._parent != viewModel)
+                {
+                    item._parent = viewModel;
+                }
+            }
+
+            while (viewModel.ItemList.Count > 0)
+            {
+                viewModel.ItemList.FirstOrDefault().AddCount(false);
+            }
+            Main.dataBase.SaveAllJSONs();
+            EquipmentWindow.INSTANCE.reloadItems();
+        }
+
+        private void RemoveFromParentAll()
+        {
+            foreach (AutoAddSingleItem item in viewModel.ItemList)
+            {
+                if (item._parent != viewModel)
+                {
+                    item._parent = viewModel;
+                }
+            }
+
+            while (viewModel.ItemList.Count > 0)
+            {
+                viewModel.ItemList.FirstOrDefault().Remove.Execute(null);
+            }
+        }
+
+        // Allows the draging of the window
+        private new void MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ChangedButton == MouseButton.Left)
+                DragMove();
+        }
+
+        private void RedirectScrollToParent(object sender, MouseWheelEventArgs e)
+        {
+            object tmp = VisualTreeHelper.GetParent(sender as DependencyObject);
+            if (tmp is ScrollContentPresenter)
+            {
+                ScrollContentPresenter SCP = tmp as ScrollContentPresenter;
+                MouseWheelEventArgs eventArgs = new MouseWheelEventArgs(e.MouseDevice, e.Timestamp, e.Delta);
+                eventArgs.RoutedEvent = MouseWheelEvent;
+                eventArgs.Source = sender;
+                SCP.RaiseEvent(eventArgs);
+            }
+        }
+    }
+}

--- a/WFInfo/Data.cs
+++ b/WFInfo/Data.cs
@@ -1029,7 +1029,8 @@ namespace WFInfo
                 Overlay.rewardsDisplaying = true;
             }
 
-            if (!line.Contains("MatchingService::EndSession") || !_settings.AutoList) return;
+            //abort if autolist disabled, or line doesn't contain end-of-session message or timer finished message
+            if (!(line.Contains("MatchingService::EndSession") || line.Contains("Relic timer closed")) || !_settings.AutoList) return;
 
             if (Main.listingHelper.PrimeRewards == null || Main.listingHelper.PrimeRewards.Count == 0)
             {
@@ -1048,7 +1049,14 @@ namespace WFInfo
                 Main.AddLog("Looping through rewards");
                 foreach (var rewardscreen in Main.listingHelper.PrimeRewards)
                 {
-                    Main.AddLog(rewardscreen.ToString());
+                    string rewards = "";
+                    for(int i = 0; i < rewardscreen.Count; i++)
+                    {
+                        rewards += rewardscreen[i];
+                        if (i + 1 < rewardscreen.Count)
+                            rewards += " || ";
+                    }
+                    Main.AddLog(rewards);
                     var rewardCollection = Task.Run(() => Main.listingHelper.GetRewardCollection(rewardscreen)).Result;
                     if (rewardCollection.PrimeNames.Count == 0)
                         return;

--- a/WFInfo/Main.cs
+++ b/WFInfo/Main.cs
@@ -311,7 +311,7 @@ namespace WFInfo
             }
             else if (key == MouseButton.Left && OCR.Warframe != null && !OCR.Warframe.HasExited && Overlay.rewardsDisplaying)
             {
-                if (_settings.Display != Display.Overlay && _settings.AutoList == false)
+                if (_settings.Display != Display.Overlay && !_settings.AutoList && !_settings.AutoCSV)
                 {
                     Overlay.rewardsDisplaying = false; //only "naturally" set to false on overlay disappearing and/or specific log message with auto-list enabled
                     return;

--- a/WFInfo/Main.cs
+++ b/WFInfo/Main.cs
@@ -305,11 +305,16 @@ namespace WFInfo
             }
             else if (key == MouseButton.Left && OCR.Warframe != null && !OCR.Warframe.HasExited && Overlay.rewardsDisplaying)
             {
+                if (_settings.Display != Display.Overlay && _settings.AutoList == false)
+                {
+                    Overlay.rewardsDisplaying = false; //only "naturally" set to false on overlay disappearing and/or specific log message with auto-list enabled
+                    return;
+                }
                 Task.Run((() =>
                 {
                     lastClick = System.Windows.Forms.Cursor.Position;
                     int index = OCR.GetSelectedReward(lastClick);
-                    Debug.WriteLine(index);
+                    Main.AddLog("Chosen reward index: " + index);
                     if (index < 0) return;
                     listingHelper.SelectedRewardIndex = (short)index;
                 }));

--- a/WFInfo/Main.cs
+++ b/WFInfo/Main.cs
@@ -25,6 +25,7 @@ namespace WFInfo
         public static Overlay[] overlays = new Overlay[4] { new Overlay(), new Overlay(), new Overlay(), new Overlay() };
         public static EquipmentWindow equipmentWindow = new EquipmentWindow();
         public static SettingsWindow settingsWindow = new SettingsWindow();
+        public static ThemeAdjuster themeAdjuster = new ThemeAdjuster();
         public static VerifyCount verifyCount = new VerifyCount();
         public static ErrorDialogue popup;
         public static FullscreenReminder fullscreenpopup;

--- a/WFInfo/Main.cs
+++ b/WFInfo/Main.cs
@@ -27,6 +27,7 @@ namespace WFInfo
         public static SettingsWindow settingsWindow = new SettingsWindow();
         public static ThemeAdjuster themeAdjuster = new ThemeAdjuster();
         public static VerifyCount verifyCount = new VerifyCount();
+        public static AutoCount autoCount = new AutoCount();
         public static ErrorDialogue popup;
         public static FullscreenReminder fullscreenpopup;
         public static UpdateDialogue update;
@@ -311,7 +312,7 @@ namespace WFInfo
             }
             else if (key == MouseButton.Left && OCR.Warframe != null && !OCR.Warframe.HasExited && Overlay.rewardsDisplaying)
             {
-                if (_settings.Display != Display.Overlay && !_settings.AutoList && !_settings.AutoCSV)
+                if (_settings.Display != Display.Overlay && !_settings.AutoList && !_settings.AutoCSV && !_settings.AutoCount)
                 {
                     Overlay.rewardsDisplaying = false; //only "naturally" set to false on overlay disappearing and/or specific log message with auto-list enabled
                     return;

--- a/WFInfo/Main.cs
+++ b/WFInfo/Main.cs
@@ -111,6 +111,12 @@ namespace WFInfo
             if (OCR.Warframe != null && OCR.Warframe.HasExited && LastMarketStatus != "invisible")
             {//set user offline if Warframe has closed but no new game was found
                 Debug.WriteLine($"Warframe was detected as closed");
+                //reset warframe process variables, and reset LogCapture so new game process gets noticed
+                dataBase.DisableLogCapture();
+                OCR.Warframe.Dispose();
+                OCR.Warframe = null;
+                if (ApplicationSettings.GlobalReadonlySettings.Auto)
+                    dataBase.EnableLogCapture();
 
                 await Task.Run(async () =>
                 {

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -1892,7 +1892,7 @@ namespace WFInfo
             }
         }
 
-        private static Bitmap ScaleUpAndFilter(Bitmap image, WFtheme active, out int[] rowHits, out int[] colHits)
+        public static Bitmap ScaleUpAndFilter(Bitmap image, WFtheme active, out int[] rowHits, out int[] colHits)
         {
             Bitmap filtered;
             if (image.Height <= SCALING_LIMIT)

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -26,6 +26,29 @@ using Size = System.Drawing.Size;
 
 namespace WFInfo
 {
+    public enum WFtheme : int
+    {
+        VITRUVIAN,
+        STALKER,
+        BARUUK,
+        CORPUS,
+        FORTUNA,
+        GRINEER,
+        LOTUS,
+        NIDUS,
+        OROKIN,
+        TENNO,
+        HIGH_CONTRAST,
+        LEGACY,
+        EQUINOX,
+        DARK_LOTUS,
+        ZEPHYR,
+        UNKNOWN = -1,
+        AUTO = -2,
+        CUSTOM = -3
+
+    }
+
     class OCR
     {
         private static readonly string applicationDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\WFInfo";
@@ -33,25 +56,7 @@ namespace WFInfo
         private static Screen wfScreen = Screen.PrimaryScreen;
 
         #region variabels and sizzle
-        public enum WFtheme : int
-        {
-            VITRUVIAN,
-            STALKER,
-            BARUUK,
-            CORPUS,
-            FORTUNA,
-            GRINEER,
-            LOTUS,
-            NIDUS,
-            OROKIN,
-            TENNO,
-            HIGH_CONTRAST,
-            LEGACY,
-            EQUINOX,
-            DARK_LOTUS,
-            ZEPHYR,
-            UNKNOWN = -1
-        }
+
 
         // Colors for the top left "profile bar"
         public static Color[] ThemePrimary = new Color[] {  Color.FromArgb(190, 169, 102),		//VITRUVIAN		
@@ -582,7 +587,7 @@ namespace WFInfo
 
             foreach (WFtheme theme in (WFtheme[])Enum.GetValues(typeof(WFtheme)))
             {
-                if (theme != WFtheme.UNKNOWN)
+                if ((int)theme >= 0) //ignore special theme values
                 {
                     Color themeColor = ThemePrimary[(int)theme];
                     int tempThresh = ColorDifference(clr, themeColor);

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -2434,6 +2434,16 @@ namespace WFInfo
             if (Warframe != null && !Warframe.HasExited) { // don't update status
                 return true;
             }
+            if (Warframe!= null && Warframe.HasExited)
+            {
+                //reset warframe process variables, and reset LogCapture so new game process gets noticed
+                Main.dataBase.DisableLogCapture();
+                Warframe.Dispose();
+                Warframe = null;
+                if (ApplicationSettings.GlobalReadonlySettings.Auto)
+                    Main.dataBase.EnableLogCapture();
+            }
+
             Task.Run(() => {
                 foreach (Process process in Process.GetProcesses())
                     if (process.ProcessName == "Warframe.x64") {
@@ -2459,6 +2469,7 @@ namespace WFInfo
                                 return true;
                             }
                             catch (System.ComponentModel.Win32Exception e) {
+                                Warframe = null;
                                 Main.AddLog($"Failed to get Warframe process due to: {e.Message}");
                                 Main.StatusUpdate("Restart Warframe without admin privileges", 1);
                                 return _settings.Debug ? true : false;

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -568,6 +568,11 @@ namespace WFInfo
             }
             Main.AddLog("CLOSEST THEME(" + max.ToString("F2", Main.culture) + "): " + active.ToString());
             closestThresh = max;
+            if (_settings.ThemeSelection != WFtheme.AUTO)
+            {
+                Main.AddLog("Theme overwrite present, setting to: " + _settings.ThemeSelection.ToString());
+                return _settings.ThemeSelection;
+            }
             return active;
         }
 #pragma warning disable IDE0044 // Add readonly modifier
@@ -1795,8 +1800,48 @@ namespace WFInfo
             return Math.Abs(test.R - thresh.R) + Math.Abs(test.G - thresh.G) + Math.Abs(test.B - thresh.B);
         }
 
+        public static bool CustomThresholdFilter(Color test)
+        {
+            if (_settings.CF_usePrimaryHSL)
+            {
+                if (_settings.CF_pHueMax >= test.GetHue() && test.GetHue() >= _settings.CF_pHueMin &&
+                    _settings.CF_pSatMax >= test.GetSaturation() && test.GetSaturation() >= _settings.CF_pSatMin &&
+                    _settings.CF_pBrightMax >= test.GetBrightness() && test.GetBrightness() >= _settings.CF_pBrightMin)
+                    return true;
+            }
+
+            if (_settings.CF_usePrimaryRGB)
+            {
+                if (_settings.CF_pRMax >= test.R && test.R >= _settings.CF_pRMin &&
+                    _settings.CF_pGMax >= test.G && test.G >= _settings.CF_pGMin &&
+                    _settings.CF_pBMax >= test.B && test.B >= _settings.CF_pBMin)
+                    return true;
+            }
+
+            if (_settings.CF_useSecondaryHSL)
+            {
+                if (_settings.CF_sHueMax >= test.GetHue() && test.GetHue() >= _settings.CF_sHueMin &&
+                    _settings.CF_sSatMax >= test.GetSaturation() && test.GetSaturation() >= _settings.CF_sSatMin &&
+                    _settings.CF_sBrightMax >= test.GetBrightness() && test.GetBrightness() >= _settings.CF_sBrightMin)
+                    return true;
+            }
+
+            if (_settings.CF_useSecondaryRGB)
+            {
+                if (_settings.CF_sRMax >= test.R && test.R >= _settings.CF_sRMin &&
+                    _settings.CF_sGMax >= test.G && test.G >= _settings.CF_sGMin &&
+                    _settings.CF_sBMax >= test.B && test.B >= _settings.CF_sBMin)
+                    return true;
+            }
+
+
+            return false;
+        }
+
         public static bool ThemeThresholdFilter(Color test, WFtheme theme)
         {
+            if (theme == WFtheme.CUSTOM)
+                return CustomThresholdFilter(test);
             Color primary = ThemePrimary[(int)theme];
             Color secondary = ThemeSecondary[(int)theme];
 
@@ -1947,7 +1992,6 @@ namespace WFInfo
             start = watch.ElapsedMilliseconds;
             
             active = GetThemeWeighted(out var closest, fullScreen);
-            Main.AddLog("CLOSEST THEME(" + closest.ToString("F2", Main.culture) + "): " + active);
 
             end = watch.ElapsedMilliseconds;
             Main.AddLog("Got theme " + (end - start) + "ms");

--- a/WFInfo/Settings/ApplicationSettings.cs
+++ b/WFInfo/Settings/ApplicationSettings.cs
@@ -83,6 +83,34 @@ namespace WFInfo.Settings
         public int MaxOverlayWidth { get; set; } = 160;
 
         public WFtheme ThemeSelection { get; set; } = WFtheme.AUTO;
+        public bool CF_usePrimaryHSL { get; set; } = false;
+        public bool CF_usePrimaryRGB { get; set; } = false;
+        public bool CF_useSecondaryHSL { get; set; } = false;
+        public bool CF_useSecondaryRGB { get; set; } = false;
+        public float CF_pHueMax { get; set; } = 360.0F;
+        public float CF_pHueMin { get; set; } = 0.0F;
+        public float CF_pSatMax { get; set; } = 1.0F;
+        public float CF_pSatMin { get; set; } = 0.0F;
+        public float CF_pBrightMax { get; set; } = 1.0F;
+        public float CF_pBrightMin { get; set; } = 0.0F;
+        public int CF_pRMax { get; set; } = 255;
+        public int CF_pRMin { get; set; } = 0;
+        public int CF_pGMax { get; set; } = 255;
+        public int CF_pGMin { get; set; } = 0;
+        public int CF_pBMax { get; set; } = 255;
+        public int CF_pBMin { get; set; } = 0;
+        public float CF_sHueMax { get; set; } = 360.0F;
+        public float CF_sHueMin { get; set; } = 0.0F;
+        public float CF_sSatMax { get; set; } = 1.0F;
+        public float CF_sSatMin { get; set; } = 0.0F;
+        public float CF_sBrightMax { get; set; } = 1.0F;
+        public float CF_sBrightMin { get; set; } = 0.0F;
+        public int CF_sRMax { get; set; } = 255;
+        public int CF_sRMin { get; set; } = 0;
+        public int CF_sGMax { get; set; } = 255;
+        public int CF_sGMin { get; set; } = 0;
+        public int CF_sBMax { get; set; } = 255;
+        public int CF_sBMin { get; set; } = 0;
         public string Ignored { get; set; } = null;
         [OnError]
         internal void OnError(StreamingContext context, ErrorContext errorContext)

--- a/WFInfo/Settings/ApplicationSettings.cs
+++ b/WFInfo/Settings/ApplicationSettings.cs
@@ -68,6 +68,7 @@ namespace WFInfo.Settings
         public int OverlayYOffsetValue { get; set; } = 0;
         public bool AutoList { get; set; } = false;
         public bool AutoCSV { get; set; } = false;
+        public bool AutoCount { get; set; } = false;
         public bool DoDoubleCheck { get; set; } = true;
         public double MaximumEfficiencyValue { get; set; } = 9.5;
         public double MinimumEfficiencyValue { get; set; } = 4.5;

--- a/WFInfo/Settings/ApplicationSettings.cs
+++ b/WFInfo/Settings/ApplicationSettings.cs
@@ -67,6 +67,7 @@ namespace WFInfo.Settings
         public int OverlayXOffsetValue { get; set; } = 0;
         public int OverlayYOffsetValue { get; set; } = 0;
         public bool AutoList { get; set; } = false;
+        public bool AutoCSV { get; set; } = false;
         public bool DoDoubleCheck { get; set; } = true;
         public double MaximumEfficiencyValue { get; set; } = 9.5;
         public double MinimumEfficiencyValue { get; set; } = 4.5;

--- a/WFInfo/Settings/ApplicationSettings.cs
+++ b/WFInfo/Settings/ApplicationSettings.cs
@@ -81,6 +81,8 @@ namespace WFInfo.Settings
         public double SnapColEmptyDensity { get; set; } = 0.005;
         public int MinOverlayWidth { get; set; } = 120;
         public int MaxOverlayWidth { get; set; } = 160;
+
+        public WFtheme ThemeSelection { get; set; } = WFtheme.AUTO;
         public string Ignored { get; set; } = null;
         [OnError]
         internal void OnError(StreamingContext context, ErrorContext errorContext)

--- a/WFInfo/Settings/IReadOnlyApplicationSettings.cs
+++ b/WFInfo/Settings/IReadOnlyApplicationSettings.cs
@@ -56,6 +56,7 @@ namespace WFInfo.Settings
         double SnapColEmptyDensity { get; }
         int MinOverlayWidth { get; }
         int MaxOverlayWidth { get; }
+        WFtheme ThemeSelection { get; }
         string Ignored { get; }
     }
 }

--- a/WFInfo/Settings/IReadOnlyApplicationSettings.cs
+++ b/WFInfo/Settings/IReadOnlyApplicationSettings.cs
@@ -43,6 +43,7 @@ namespace WFInfo.Settings
         int OverlayYOffsetValue { get; }
         bool AutoList { get; }
         bool AutoCSV { get; }
+        bool AutoCount { get; }
         bool DoDoubleCheck { get; }
         double MaximumEfficiencyValue { get; }
         double MinimumEfficiencyValue { get; }

--- a/WFInfo/Settings/IReadOnlyApplicationSettings.cs
+++ b/WFInfo/Settings/IReadOnlyApplicationSettings.cs
@@ -57,6 +57,34 @@ namespace WFInfo.Settings
         int MinOverlayWidth { get; }
         int MaxOverlayWidth { get; }
         WFtheme ThemeSelection { get; }
+        bool CF_usePrimaryHSL { get; }
+        bool CF_usePrimaryRGB { get; }
+        bool CF_useSecondaryHSL { get; }
+        bool CF_useSecondaryRGB { get; }
+        float CF_pHueMax { get; }
+        float CF_pHueMin { get; }
+        float CF_pSatMax { get; }
+        float CF_pSatMin { get; }
+        float CF_pBrightMax { get; }
+        float CF_pBrightMin { get; }
+        int CF_pRMax { get; }
+        int CF_pRMin { get; }
+        int CF_pGMax { get; }
+        int CF_pGMin { get; }
+        int CF_pBMax { get; }
+        int CF_pBMin { get; }
+        float CF_sHueMax { get; }
+        float CF_sHueMin { get; }
+        float CF_sSatMax { get; }
+        float CF_sSatMin { get; }
+        float CF_sBrightMax { get; }
+        float CF_sBrightMin { get; }
+        int CF_sRMax { get; }
+        int CF_sRMin { get; }
+        int CF_sGMax { get; }
+        int CF_sGMin { get; }
+        int CF_sBMax { get; }
+        int CF_sBMin { get; }
         string Ignored { get; }
     }
 }

--- a/WFInfo/Settings/IReadOnlyApplicationSettings.cs
+++ b/WFInfo/Settings/IReadOnlyApplicationSettings.cs
@@ -42,6 +42,7 @@ namespace WFInfo.Settings
         int OverlayXOffsetValue { get; }
         int OverlayYOffsetValue { get; }
         bool AutoList { get; }
+        bool AutoCSV { get; }
         bool DoDoubleCheck { get; }
         double MaximumEfficiencyValue { get; }
         double MinimumEfficiencyValue { get; }

--- a/WFInfo/Settings/SettingsViewModel.cs
+++ b/WFInfo/Settings/SettingsViewModel.cs
@@ -379,6 +379,16 @@ namespace WFInfo.Settings
             }
         }
 
+        public WFtheme ThemeSelection
+        {
+            get => _settings.ThemeSelection;
+            set
+            {
+                _settings.ThemeSelection = value;
+                RaisePropertyChanged();
+            }
+        }
+
         public string Ignored{
             get => _settings.Ignored;
             set { 

--- a/WFInfo/Settings/SettingsViewModel.cs
+++ b/WFInfo/Settings/SettingsViewModel.cs
@@ -253,6 +253,15 @@ namespace WFInfo.Settings
                 RaisePropertyChanged();
             }
         }
+        public bool AutoCount
+        {
+            get => _settings.AutoCount;
+            set
+            {
+                _settings.AutoCount = value;
+                RaisePropertyChanged();
+            }
+        }
 
         public double MaximumEfficiencyValue
         {

--- a/WFInfo/Settings/SettingsViewModel.cs
+++ b/WFInfo/Settings/SettingsViewModel.cs
@@ -236,9 +236,21 @@ namespace WFInfo.Settings
         public bool AutoList
         {
             get => _settings.AutoList;
-            set { 
+            set
+            {
                 _settings.AutoList = value;
-                RaisePropertyChanged(); 
+                RaisePropertyChanged();
+            }
+        }
+
+
+        public bool AutoCSV
+        {
+            get => _settings.AutoCSV;
+            set
+            {
+                _settings.AutoCSV = value;
+                RaisePropertyChanged();
             }
         }
 

--- a/WFInfo/Settings/SettingsViewModel.cs
+++ b/WFInfo/Settings/SettingsViewModel.cs
@@ -388,6 +388,257 @@ namespace WFInfo.Settings
                 RaisePropertyChanged();
             }
         }
+        public bool CF_usePrimaryHSL { get => _settings.CF_usePrimaryHSL;
+            set 
+            {
+                _settings.CF_usePrimaryHSL = value;
+                RaisePropertyChanged();
+            }
+        }
+        public bool CF_usePrimaryRGB
+        {
+            get => _settings.CF_usePrimaryRGB;
+            set
+            {
+                _settings.CF_usePrimaryRGB = value;
+                RaisePropertyChanged();
+            }
+        }
+        public bool CF_useSecondaryHSL
+        {
+            get => _settings.CF_useSecondaryHSL;
+            set
+            {
+                _settings.CF_useSecondaryHSL = value;
+                RaisePropertyChanged();
+            }
+        }
+        public bool CF_useSecondaryRGB
+        {
+            get => _settings.CF_useSecondaryRGB;
+            set
+            {
+                _settings.CF_useSecondaryRGB = value;
+                RaisePropertyChanged();
+            }
+        }
+        public float CF_pHueMax
+        {
+            get => _settings.CF_pHueMax;
+            set
+            {
+                _settings.CF_pHueMax = value;
+                RaisePropertyChanged();
+            }
+        }
+        public float CF_pHueMin
+        {
+            get => _settings.CF_pHueMin;
+            set
+            {
+                _settings.CF_pHueMin = value;
+                RaisePropertyChanged();
+            }
+        }
+        public float CF_pSatMax
+        {
+            get => _settings.CF_pSatMax;
+            set
+            {
+                _settings.CF_pSatMax = value;
+                RaisePropertyChanged();
+            }
+        }
+        public float CF_pSatMin
+        {
+            get => _settings.CF_pSatMin;
+            set
+            {
+                _settings.CF_pSatMin = value;
+                RaisePropertyChanged();
+            }
+        }
+        public float CF_pBrightMax
+        {
+            get => _settings.CF_pBrightMax;
+            set
+            {
+                _settings.CF_pBrightMax = value;
+                RaisePropertyChanged();
+            }
+        }
+        public float CF_pBrightMin
+        {
+            get => _settings.CF_pBrightMin;
+            set
+            {
+                _settings.CF_pBrightMin = value;
+                RaisePropertyChanged();
+            }
+        }
+        public int CF_pRMax
+        {
+            get => _settings.CF_pRMax;
+            set
+            {
+                _settings.CF_pRMax = value;
+                RaisePropertyChanged();
+            }
+        }
+        public int CF_pRMin
+        {
+            get => _settings.CF_pRMin;
+            set
+            {
+                _settings.CF_pRMin = value;
+                RaisePropertyChanged();
+            }
+        }
+        public int CF_pGMax
+        {
+            get => _settings.CF_pGMax;
+            set
+            {
+                _settings.CF_pGMax = value;
+                RaisePropertyChanged();
+            }
+        }
+        public int CF_pGMin
+        {
+            get => _settings.CF_pGMin;
+            set
+            {
+                _settings.CF_pGMin = value;
+                RaisePropertyChanged();
+            }
+        }
+        public int CF_pBMax
+        {
+            get => _settings.CF_pBMax;
+            set
+            {
+                _settings.CF_pBMax = value;
+                RaisePropertyChanged();
+            }
+        }
+        public int CF_pBMin
+        {
+            get => _settings.CF_pBMin;
+            set
+            {
+                _settings.CF_pBMin = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public float CF_sHueMax
+        {
+            get => _settings.CF_sHueMax;
+            set
+            {
+                _settings.CF_sHueMax = value;
+                RaisePropertyChanged();
+            }
+        }
+        public float CF_sHueMin
+        {
+            get => _settings.CF_sHueMin;
+            set
+            {
+                _settings.CF_sHueMin = value;
+                RaisePropertyChanged();
+            }
+        }
+        public float CF_sSatMax
+        {
+            get => _settings.CF_sSatMax;
+            set
+            {
+                _settings.CF_sSatMax = value;
+                RaisePropertyChanged();
+            }
+        }
+        public float CF_sSatMin
+        {
+            get => _settings.CF_sSatMin;
+            set
+            {
+                _settings.CF_sSatMin = value;
+                RaisePropertyChanged();
+            }
+        }
+        public float CF_sBrightMax
+        {
+            get => _settings.CF_sBrightMax;
+            set
+            {
+                _settings.CF_sBrightMax = value;
+                RaisePropertyChanged();
+            }
+        }
+        public float CF_sBrightMin
+        {
+            get => _settings.CF_sBrightMin;
+            set
+            {
+                _settings.CF_sBrightMin = value;
+                RaisePropertyChanged();
+            }
+        }
+        public int CF_sRMax
+        {
+            get => _settings.CF_sRMax;
+            set
+            {
+                _settings.CF_sRMax = value;
+                RaisePropertyChanged();
+            }
+        }
+        public int CF_sRMin
+        {
+            get => _settings.CF_sRMin;
+            set
+            {
+                _settings.CF_sRMin = value;
+                RaisePropertyChanged();
+            }
+        }
+        public int CF_sGMax
+        {
+            get => _settings.CF_sGMax;
+            set
+            {
+                _settings.CF_sGMax = value;
+                RaisePropertyChanged();
+            }
+        }
+        public int CF_sGMin
+        {
+            get => _settings.CF_sGMin;
+            set
+            {
+                _settings.CF_sGMin = value;
+                RaisePropertyChanged();
+            }
+        }
+        public int CF_sBMax
+        {
+            get => _settings.CF_sBMax;
+            set
+            {
+                _settings.CF_sBMax = value;
+                RaisePropertyChanged();
+            }
+        }
+        public int CF_sBMin
+        {
+            get => _settings.CF_sBMin;
+            set
+            {
+                _settings.CF_sBMin = value;
+                RaisePropertyChanged();
+            }
+        }
 
         public string Ignored{
             get => _settings.Ignored;

--- a/WFInfo/Settings/SettingsViewModel.cs
+++ b/WFInfo/Settings/SettingsViewModel.cs
@@ -242,15 +242,6 @@ namespace WFInfo.Settings
             }
         }
 
-        public bool DoDoubleCheck
-        {
-            get => _settings.DoDoubleCheck;
-            set { 
-                _settings.DoDoubleCheck = value;
-                RaisePropertyChanged(); 
-            }
-        }
-
         public double MaximumEfficiencyValue
         {
             get => _settings.MaximumEfficiencyValue;

--- a/WFInfo/Settings/SettingsWindow.xaml
+++ b/WFInfo/Settings/SettingsWindow.xaml
@@ -470,18 +470,20 @@
                         </Border>
                         <Border DockPanel.Dock="Top"
                                 Style="{StaticResource NestedBorder}">
-                            <UniformGrid Rows="1">
+                            <UniformGrid Rows="2">
 
                                 <CheckBox x:Name="autoCheckbox"
-                                          DockPanel.Dock="Right"
                                           Content="Auto"
                                           ToolTip="Automatically detects when the relic screen is visible."
                                           Click="AutoClicked" />
                                 <CheckBox x:Name="Autolist"
-                                          DockPanel.Dock="Left"
                                           Content="Auto list"
                                           ToolTip="Spawns a listing dialogue whenever the end of mission is detected, requires auto"
                                           IsChecked="{Binding SettingsViewModel.AutoList, Mode=TwoWay}" />
+                                <CheckBox x:Name="Autocsv"
+                                          Content="Auto CSV"
+                                          ToolTip="Save reward options and choice to CSV file in application directory (%appdata%/WFInfo%)"
+                                          IsChecked="{Binding SettingsViewModel.AutoCSV, Mode=TwoWay}" />
                             </UniformGrid>
                         </Border>
                     </DockPanel>

--- a/WFInfo/Settings/SettingsWindow.xaml
+++ b/WFInfo/Settings/SettingsWindow.xaml
@@ -477,7 +477,7 @@
                                           ToolTip="Automatically detects when the relic screen is visible."
                                           Click="AutoClicked" />
                                 <CheckBox x:Name="Autolist"
-                                          Content="Auto list"
+                                          Content="Auto List"
                                           ToolTip="Spawns a listing dialogue whenever the end of mission is detected, requires auto"
                                           IsChecked="{Binding SettingsViewModel.AutoList, Mode=TwoWay}" />
                                 <CheckBox x:Name="Autocsv"
@@ -485,7 +485,7 @@
                                           ToolTip="Save reward options and choice to CSV file in application directory (%appdata%/WFInfo%)"
                                           IsChecked="{Binding SettingsViewModel.AutoCSV, Mode=TwoWay}" />
                                 <CheckBox x:Name="Autoadd"
-                                          Content="Auto add"
+                                          Content="Auto Add"
                                           ToolTip="Spawns a dialogue for increasing owned item count whenever the end of mission is detected, requires auto"
                                           IsChecked="{Binding SettingsViewModel.AutoCount, Mode=TwoWay}" />
                             </UniformGrid>

--- a/WFInfo/Settings/SettingsWindow.xaml
+++ b/WFInfo/Settings/SettingsWindow.xaml
@@ -484,6 +484,10 @@
                                           Content="Auto CSV"
                                           ToolTip="Save reward options and choice to CSV file in application directory (%appdata%/WFInfo%)"
                                           IsChecked="{Binding SettingsViewModel.AutoCSV, Mode=TwoWay}" />
+                                <CheckBox x:Name="Autoadd"
+                                          Content="Auto add"
+                                          ToolTip="Spawns a dialogue for increasing owned item count whenever the end of mission is detected, requires auto"
+                                          IsChecked="{Binding SettingsViewModel.AutoCount, Mode=TwoWay}" />
                             </UniformGrid>
                         </Border>
                     </DockPanel>

--- a/WFInfo/Settings/SettingsWindow.xaml
+++ b/WFInfo/Settings/SettingsWindow.xaml
@@ -11,7 +11,7 @@
         MaxWidth="334"
         MinWidth="334"
         Width="334"
-        Height="900"
+        Height="634"
         BorderBrush="#FF707070"
         WindowStyle="None"
         FontSize="16"
@@ -382,10 +382,15 @@
                 <Border Padding="0"
                         DockPanel.Dock="Top">
                     <DockPanel>
-                        <UniformGrid DockPanel.Dock="Top"
-                                         Rows="1">
-                            <Label Content="Theme" DockPanel.Dock="Left"/>
-                            <Label x:Name="ConfigureTheme_button"  MouseLeftButtonDown="ConfigureTheme_button_MouseLeftButtonDown" ToolTip="Configure Custom Theme" Margin="0,5,10,5" Padding="3"  HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Height="20" VerticalAlignment="Top" HorizontalAlignment="Right" Width="20">
+                        <Grid DockPanel.Dock="Top">
+
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition/>
+                                <ColumnDefinition Width="6*"/>
+                            </Grid.ColumnDefinitions>
+                            <Label Content="Theme" Grid.Column="0"/>
+                            <Label x:Name="ConfigureTheme_button" Grid.Column="1" MouseLeftButtonDown="ConfigureTheme_button_MouseLeftButtonDown" ToolTip="Configure Custom Theme" Margin="0,5,10,5" Padding="3"  HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Height="20" VerticalAlignment="Top" HorizontalAlignment="Right" Width="20">
                                 <Label.Style>
                                     <Style>
                                         <Setter Property="ContentControl.Content">
@@ -410,7 +415,7 @@
                                 </Label.Style>
                             </Label>
                             <ComboBox 
-                                          DockPanel.Dock="Right"
+                                          Grid.Column="2"
                                           x:Name="themeSelectionComboBox"
                                           FontSize="14"
                                           FontFamily="{DynamicResource Roboto}"
@@ -418,10 +423,10 @@
                                           BorderBrush="#FF0F0F0F"
                                           ItemsSource="{Binding Source={StaticResource enumWFTheme}}"
                                           SelectedItem="{Binding SettingsViewModel.ThemeSelection}"
-                                          Margin="0,4" Template="{DynamicResource ComboBoxTemplate}" Style="{DynamicResource ComboBoxStyle1}">
+                                          Margin="5,4" Template="{DynamicResource ComboBoxTemplate}" Style="{DynamicResource ComboBoxStyle1}">
 
                             </ComboBox>
-                        </UniformGrid>
+                        </Grid>
                         <Label MouseLeftButtonDown="ClickCreateDebug"
                                Padding="5"
                                DockPanel.Dock="Right"

--- a/WFInfo/Settings/SettingsWindow.xaml
+++ b/WFInfo/Settings/SettingsWindow.xaml
@@ -10,6 +10,7 @@
         Title="Settings"
         MaxWidth="334"
         MinWidth="334"
+
         Height="634"
         BorderBrush="#FF707070"
         WindowStyle="None"

--- a/WFInfo/Settings/SettingsWindow.xaml
+++ b/WFInfo/Settings/SettingsWindow.xaml
@@ -10,14 +10,21 @@
         Title="Settings"
         MaxWidth="334"
         MinWidth="334"
-
-        Height="634"
+        Width="334"
+        Height="900"
         BorderBrush="#FF707070"
         WindowStyle="None"
         FontSize="16"
         d:DataContext="{d:DesignInstance Type=settings:SettingsWindow}"
         AllowsTransparency="True"
         ResizeMode="CanResizeWithGrip">
+    <Window.Resources>
+        <ObjectDataProvider x:Key="enumWFTheme" MethodName="GetValues" ObjectType="{x:Type wfInfo:WFtheme}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="wfInfo:WFtheme"/>
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
+    </Window.Resources>
     <Grid MouseDown="MouseDown"
           PreviewMouseDown="ActivationMouseDown"
           Background="#FF1B1B1B"
@@ -375,6 +382,46 @@
                 <Border Padding="0"
                         DockPanel.Dock="Top">
                     <DockPanel>
+                        <UniformGrid DockPanel.Dock="Top"
+                                         Rows="1">
+                            <Label Content="Theme" DockPanel.Dock="Left"/>
+                            <Label x:Name="ConfigureTheme_button"  MouseLeftButtonDown="ConfigureTheme_button_MouseLeftButtonDown" ToolTip="Configure Custom Theme" Margin="0,5,10,5" Padding="3"  HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Height="20" VerticalAlignment="Top" HorizontalAlignment="Right" Width="20">
+                                <Label.Style>
+                                    <Style>
+                                        <Setter Property="ContentControl.Content">
+                                            <Setter.Value>
+                                                <Image Source="../Resources/Settings.png" Stretch="Uniform" />
+                                            </Setter.Value>
+                                        </Setter>
+                                        <Style.Triggers>
+                                            <MultiTrigger>
+                                                <MultiTrigger.Conditions>
+                                                    <Condition Property="UIElement.IsMouseOver" Value="True"/>
+                                                    <Condition Property="UIElement.IsEnabled" Value="True"/>
+                                                </MultiTrigger.Conditions>
+                                                <Setter Property="ContentControl.Content">
+                                                    <Setter.Value>
+                                                        <Image Source="../Resources/Settings_h.png" Stretch="Uniform" />
+                                                    </Setter.Value>
+                                                </Setter>
+                                            </MultiTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Label.Style>
+                            </Label>
+                            <ComboBox 
+                                          DockPanel.Dock="Right"
+                                          x:Name="themeSelectionComboBox"
+                                          FontSize="14"
+                                          FontFamily="{DynamicResource Roboto}"
+                                          Background="#FF1B1B1B"
+                                          BorderBrush="#FF0F0F0F"
+                                          ItemsSource="{Binding Source={StaticResource enumWFTheme}}"
+                                          SelectedItem="{Binding SettingsViewModel.ThemeSelection}"
+                                          Margin="0,4" Template="{DynamicResource ComboBoxTemplate}" Style="{DynamicResource ComboBoxStyle1}">
+
+                            </ComboBox>
+                        </UniformGrid>
                         <Label MouseLeftButtonDown="ClickCreateDebug"
                                Padding="5"
                                DockPanel.Dock="Right"

--- a/WFInfo/Settings/SettingsWindow.xaml.cs
+++ b/WFInfo/Settings/SettingsWindow.xaml.cs
@@ -252,7 +252,7 @@ namespace WFInfo.Settings
 
         private void ConfigureTheme_button_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
-            //TODO open custom theme configuration
+            ThemeAdjuster.ShowThemeAdjuster();
         }
     }
 }

--- a/WFInfo/Settings/SettingsWindow.xaml.cs
+++ b/WFInfo/Settings/SettingsWindow.xaml.cs
@@ -46,10 +46,12 @@ namespace WFInfo.Settings
             {
                 autoCheckbox.IsChecked = true;
                 Autolist.IsEnabled = true;
+                Autocsv.IsEnabled = true;
             }
             else
             {
                 Autolist.IsEnabled = false;
+                Autocsv.IsEnabled = false;
             }
 
             foreach (ComboBoxItem localeItem in localeCombobox.Items)
@@ -115,6 +117,7 @@ namespace WFInfo.Settings
                 {
                     Main.dataBase.EnableLogCapture();
                     Autolist.IsEnabled = true;
+                    Autocsv.IsEnabled = true;
                 }
                 else
                 {
@@ -122,6 +125,7 @@ namespace WFInfo.Settings
                     autoCheckbox.IsChecked = false;
                     Main.dataBase.DisableLogCapture();
                     Autolist.IsEnabled = false;
+                    Autocsv.IsEnabled = false;
                 }
             }
             else

--- a/WFInfo/Settings/SettingsWindow.xaml.cs
+++ b/WFInfo/Settings/SettingsWindow.xaml.cs
@@ -47,11 +47,13 @@ namespace WFInfo.Settings
                 autoCheckbox.IsChecked = true;
                 Autolist.IsEnabled = true;
                 Autocsv.IsEnabled = true;
+                Autoadd.IsEnabled = true;
             }
             else
             {
                 Autolist.IsEnabled = false;
                 Autocsv.IsEnabled = false;
+                Autoadd.IsEnabled = false;
             }
 
             foreach (ComboBoxItem localeItem in localeCombobox.Items)
@@ -118,6 +120,7 @@ namespace WFInfo.Settings
                     Main.dataBase.EnableLogCapture();
                     Autolist.IsEnabled = true;
                     Autocsv.IsEnabled = true;
+                    Autoadd.IsEnabled = true;
                 }
                 else
                 {
@@ -126,11 +129,15 @@ namespace WFInfo.Settings
                     Main.dataBase.DisableLogCapture();
                     Autolist.IsEnabled = false;
                     Autocsv.IsEnabled = false;
+                    Autoadd.IsEnabled = false;
                 }
             }
             else
             {
                 _viewModel.Auto = false;
+                Autolist.IsEnabled = false;
+                Autocsv.IsEnabled = false;
+                Autoadd.IsEnabled = false;
                 Main.dataBase.DisableLogCapture();
             }
             Save();

--- a/WFInfo/Settings/SettingsWindow.xaml.cs
+++ b/WFInfo/Settings/SettingsWindow.xaml.cs
@@ -249,5 +249,10 @@ namespace WFInfo.Settings
             _viewModel.MasterItModifierKey = key;
             hidden.Focus();
         }
+
+        private void ConfigureTheme_button_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            //TODO open custom theme configuration
+        }
     }
 }

--- a/WFInfo/Settings/ThemeAdjuster.xaml
+++ b/WFInfo/Settings/ThemeAdjuster.xaml
@@ -135,308 +135,314 @@
                 <ColumnDefinition Width="6*"/>
                 <ColumnDefinition Width="3*"/>
             </Grid.ColumnDefinitions>
-            <Image Grid.Column="0" Margin="0,0" x:Name="previewImage"></Image>
+            <Border>
+                <Image Grid.Column="0" Margin="0,0" x:Name="previewImage"></Image>
+            </Border>
             <ScrollViewer Grid.Column="1">
                 <StackPanel>
                     <CheckBox Content="Primary HSL Filter"
                                   ToolTip="Use(and reveal) primary filter based on HSL colour values" Margin="5,5"
                                   IsChecked="{Binding SettingsViewModel.CF_usePrimaryHSL, Mode=TwoWay}" />
-                    <StackPanel  Visibility="{Binding Path=SettingsViewModel.CF_usePrimaryHSL, Converter={StaticResource BoolToVis}}">
+                    <Border>
+                        <StackPanel  Visibility="{Binding Path=SettingsViewModel.CF_usePrimaryHSL, Converter={StaticResource BoolToVis}}">
 
-                        <Label Content="Primary Hue Max"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_pHueMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
-                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
-                                 VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="360" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pHueMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Primary Hue Min"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_pHueMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
-                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
-                                 VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="360" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pHueMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Primary Saturation Max"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_pSatMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
-                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
-                                 VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pSatMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Primary Saturation Min"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_pSatMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
-                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
-                                 VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pSatMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Primary Brightness Max"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_pBrightMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
-                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
-                                 VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pBrightMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Primary Brightness Min"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_pBrightMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
-                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
-                                 VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pBrightMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                    </StackPanel>
+                            <Label Content="Primary Hue Max"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_pHueMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                     components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                     VerticalAlignment="Top" />
+                                <Slider Grid.Column="1" Minimum="0" Maximum="360" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pHueMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Primary Hue Min"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_pHueMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                     components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                     VerticalAlignment="Top" />
+                                <Slider Grid.Column="1" Minimum="0" Maximum="360" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pHueMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Primary Saturation Max"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_pSatMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                     components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                     VerticalAlignment="Top" />
+                                <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pSatMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Primary Saturation Min"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_pSatMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                     components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                     VerticalAlignment="Top" />
+                                <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pSatMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Primary Brightness Max"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_pBrightMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                     components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                     VerticalAlignment="Top" />
+                                <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pBrightMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Primary Brightness Min"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_pBrightMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                     components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                     VerticalAlignment="Top" />
+                                <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pBrightMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                        </StackPanel>
+                    </Border>
 
                     <CheckBox Content="Primary RGB Filter"
                                   ToolTip="Use(and reveal) primary filter based on RGB colour values" Margin="5,5"
                                   IsChecked="{Binding SettingsViewModel.CF_usePrimaryRGB, Mode=TwoWay}" />
-                    <StackPanel  Visibility="{Binding Path=SettingsViewModel.CF_usePrimaryRGB, Converter={StaticResource BoolToVis}}">
+                    <Border>
+                        <StackPanel  Visibility="{Binding Path=SettingsViewModel.CF_usePrimaryRGB, Converter={StaticResource BoolToVis}}">
 
-                        <Label Content="Primary Red Max"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_pRMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                            <Label Content="Primary Red Max"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_pRMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pRMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Primary Red Min"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_pRMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pRMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Primary Red Min"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_pRMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pRMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
+                                <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pRMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
 
-                        <Label Content="Primary Green Max"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_pGMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                            <Label Content="Primary Green Max"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_pGMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pGMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Primary Green Min"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_pGMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pGMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Primary Green Min"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_pGMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pGMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
+                                <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pGMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
 
-                        <Label Content="Primary Blue Max"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_pBMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                            <Label Content="Primary Blue Max"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_pBMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pBMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Primary Blue Min"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_pBMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pBMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Primary Blue Min"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_pBMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pBMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                    </StackPanel>
+                                <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pBMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                        </StackPanel>
+                    </Border>
 
                     <CheckBox Content="Secondary HSL Filter"
                                   ToolTip="Use(and reveal) secondary filter based on HSL colour values" Margin="5,5"
                                   IsChecked="{Binding SettingsViewModel.CF_useSecondaryHSL, Mode=TwoWay}" />
-                    <StackPanel  Visibility="{Binding Path=SettingsViewModel.CF_useSecondaryHSL, Converter={StaticResource BoolToVis}}">
+                    <Border>
+                        <StackPanel  Visibility="{Binding Path=SettingsViewModel.CF_useSecondaryHSL, Converter={StaticResource BoolToVis}}">
 
-                        <Label Content="Secondary Hue Max"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_sHueMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                            <Label Content="Secondary Hue Max"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_sHueMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="360" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sHueMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Secondary Hue Min"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_sHueMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                <Slider Grid.Column="1" Minimum="0" Maximum="360" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sHueMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Secondary Hue Min"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_sHueMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="360" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sHueMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Secondary Saturation Max"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_sSatMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                <Slider Grid.Column="1" Minimum="0" Maximum="360" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sHueMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Secondary Saturation Max"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_sSatMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sSatMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Secondary Saturation Min"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_sSatMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sSatMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Secondary Saturation Min"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_sSatMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sSatMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Secondary Brightness Max"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_sBrightMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sSatMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Secondary Brightness Max"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_sBrightMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sBrightMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Secondary Brightness Min"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_sBrightMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sBrightMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Secondary Brightness Min"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_sBrightMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sBrightMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                    </StackPanel>
-
-                    <!---->
+                                <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sBrightMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                        </StackPanel>
+                    </Border>
 
                     <CheckBox Content="Secondary RGB Filter"
                                   ToolTip="Use(and reveal) secondary filter based on RGB colour values" Margin="5,5"
                                   IsChecked="{Binding SettingsViewModel.CF_useSecondaryRGB, Mode=TwoWay}" />
-                    <StackPanel  Visibility="{Binding Path=SettingsViewModel.CF_useSecondaryRGB, Converter={StaticResource BoolToVis}}">
+                    <Border>
+                        <StackPanel  Visibility="{Binding Path=SettingsViewModel.CF_useSecondaryRGB, Converter={StaticResource BoolToVis}}">
 
-                        <Label Content="Secondary Red Max"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_sRMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                            <Label Content="Secondary Red Max"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_sRMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sRMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Secondary Red Min"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_sRMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sRMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Secondary Red Min"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_sRMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sRMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
+                                <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sRMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
 
-                        <Label Content="Secondary Green Max"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_sGMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                            <Label Content="Secondary Green Max"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_sGMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sGMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Secondary Green Min"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_sGMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sGMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Secondary Green Min"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_sGMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sGMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
+                                <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sGMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
 
-                        <Label Content="Secondary Blue Max"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_sBMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                            <Label Content="Secondary Blue Max"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_sBMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sBMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                        <Label Content="Secondary Blue Min"></Label>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"/>
-                                <ColumnDefinition Width="7*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBox Text="{Binding SettingsViewModel.CF_sBMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sBMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                            <Label Content="Secondary Blue Min"></Label>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*"/>
+                                    <ColumnDefinition Width="7*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SettingsViewModel.CF_sBMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
                                  components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
                                  VerticalAlignment="Top" />
-                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sBMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
-                        </Grid>
-                    </StackPanel>
-
-                    <!---->
+                                <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sBMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                            </Grid>
+                        </StackPanel>
+                    </Border>
 
                     <Grid>
                         <Grid.ColumnDefinitions>

--- a/WFInfo/Settings/ThemeAdjuster.xaml
+++ b/WFInfo/Settings/ThemeAdjuster.xaml
@@ -1,0 +1,482 @@
+<Window x:Class="WFInfo.ThemeAdjuster"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:wfInfo="clr-namespace:WFInfo"
+        xmlns:settings="clr-namespace:WFInfo.Settings"
+        xmlns:components="clr-namespace:WFInfo.Components"
+        mc:Ignorable="d"
+        Title="Theme Adjuster"
+        Width="800"
+        Height="634"
+        BorderBrush="#FF707070"
+        WindowStyle="None"
+        FontSize="16"
+        d:DataContext="{d:DesignInstance Type=settings:SettingsWindow}"
+        AllowsTransparency="True"
+        ResizeMode="CanResizeWithGrip">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+    </Window.Resources>
+    <Grid MouseDown="MouseDown"
+          Background="#FF1B1B1B"
+          MinWidth="334">
+        <Grid.Resources>
+
+            <Style x:Key="NestedBorder"
+                   TargetType="Border">
+                <Setter Property="BorderBrush"
+                        Value="#FF646464" />
+                <Setter Property="Padding"
+                        Value="5, 2" />
+                <Setter Property="BorderThickness"
+                        Value="1" />
+            </Style>
+            <Style TargetType="Border">
+                <Setter Property="BorderBrush"
+                        Value="#FF646464" />
+                <Setter Property="Padding"
+                        Value="25, 5" />
+                <Setter Property="BorderThickness"
+                        Value="1" />
+            </Style>
+            <Style x:Key="AllTextBoxes"
+                   BasedOn="{StaticResource baseStyle}"
+                   TargetType="TextBox">
+                <Setter Property="Background"
+                        Value="#FF0F0F0F" />
+                <Setter Property="BorderBrush"
+                        Value="#FFB1D0D9" />
+                <Setter Property="VerticalContentAlignment"
+                        Value="Center" />
+                <Setter Property="HorizontalContentAlignment"
+                        Value="Center" />
+                <Setter Property="Margin"
+                        Value="0, 5" />
+                <Setter Property="Padding"
+                        Value="0,1,0,2.5" />
+                <Setter Property="Cursor"
+                        Value="Arrow" />
+                <Setter Property="TextWrapping"
+                        Value="Wrap" />
+                <Setter Property="FontFamily"
+                        Value="{StaticResource Roboto}" />
+                <Setter Property="components:SelectTextOnFocus.Active"
+                        Value="True" />
+                <Setter Property="wfInfo:FocusAdvancement.AdvancesByEnterKey"
+                        Value="True" />
+            </Style>
+
+            <Style TargetType="CheckBox"
+                   BasedOn="{StaticResource baseStyle}">
+                <Setter Property="Background"
+                        Value="#FFB1D0D9" />
+                <Setter Property="BorderBrush"
+                        Value="#FF0F0F0F" />
+                <Setter Property="VerticalContentAlignment"
+                        Value="Center" />
+            </Style>
+            <Style BasedOn="{StaticResource AllTextBoxes}"
+                   TargetType="TextBox" />
+            <Style x:Key="KeyBindTextboxStyle"
+                   BasedOn="{StaticResource AllTextBoxes}"
+                   TargetType="TextBox">
+                <Setter Property="components:SelectTextOnFocus.Active"
+                        Value="False" />
+                <Style.Triggers>
+                    <Trigger Property="IsFocused"
+                             Value="True">
+                        <Setter Property="Foreground"
+                                Value="Transparent">
+                        </Setter>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+            <components:NegateIntConverter x:Key="NegateIntConverter" />
+            <components:KeyStringConverter x:Key="KeyStringConverter" />
+        </Grid.Resources>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid VerticalAlignment="Top"
+              Grid.Row="0"
+              Grid.ColumnSpan="2"
+              Grid.Column="0">
+            <Rectangle Fill="#FF0F0F0F"
+                       Stroke="#FF646464" />
+            <DockPanel>
+                <Image HorizontalAlignment="Left"
+                       VerticalAlignment="Center"
+                       Width="26"
+                       DockPanel.Dock="Left"
+                       Margin="2,0,5,1"
+                       Source="../Resources/WFLogo.png" />
+                <Label MouseLeftButtonDown="Hide"
+                       Content="x"
+                       Width="30"
+                       Style="{StaticResource Label_Button}"
+                       VerticalContentAlignment="Stretch"
+                       DockPanel.Dock="Right" />
+                <TextBlock Text="Theme Adjuster"
+                           VerticalAlignment="Center"
+                           FontSize="16"
+                           FontFamily="{StaticResource Roboto_Black}"
+                           FontWeight="Bold" />
+            </DockPanel>
+        </Grid>
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="6*"/>
+                <ColumnDefinition Width="3*"/>
+            </Grid.ColumnDefinitions>
+            <Image Grid.Column="0" Margin="0,0" x:Name="previewImage"></Image>
+            <ScrollViewer Grid.Column="1">
+                <StackPanel>
+                    <CheckBox Content="Primary HSL Filter"
+                                  ToolTip="Use(and reveal) primary filter based on HSL colour values" Margin="5,5"
+                                  IsChecked="{Binding SettingsViewModel.CF_usePrimaryHSL, Mode=TwoWay}" />
+                    <StackPanel  Visibility="{Binding Path=SettingsViewModel.CF_usePrimaryHSL, Converter={StaticResource BoolToVis}}">
+
+                        <Label Content="Primary Hue Max"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_pHueMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="360" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pHueMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Primary Hue Min"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_pHueMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="360" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pHueMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Primary Saturation Max"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_pSatMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pSatMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Primary Saturation Min"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_pSatMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pSatMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Primary Brightness Max"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_pBrightMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pBrightMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Primary Brightness Min"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_pBrightMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pBrightMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                    </StackPanel>
+
+                    <CheckBox Content="Primary RGB Filter"
+                                  ToolTip="Use(and reveal) primary filter based on RGB colour values" Margin="5,5"
+                                  IsChecked="{Binding SettingsViewModel.CF_usePrimaryRGB, Mode=TwoWay}" />
+                    <StackPanel  Visibility="{Binding Path=SettingsViewModel.CF_usePrimaryRGB, Converter={StaticResource BoolToVis}}">
+
+                        <Label Content="Primary Red Max"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_pRMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pRMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Primary Red Min"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_pRMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pRMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+
+                        <Label Content="Primary Green Max"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_pGMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pGMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Primary Green Min"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_pGMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pGMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+
+                        <Label Content="Primary Blue Max"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_pBMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pBMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Primary Blue Min"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_pBMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_pBMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                    </StackPanel>
+
+                    <CheckBox Content="Secondary HSL Filter"
+                                  ToolTip="Use(and reveal) secondary filter based on HSL colour values" Margin="5,5"
+                                  IsChecked="{Binding SettingsViewModel.CF_useSecondaryHSL, Mode=TwoWay}" />
+                    <StackPanel  Visibility="{Binding Path=SettingsViewModel.CF_useSecondaryHSL, Converter={StaticResource BoolToVis}}">
+
+                        <Label Content="Secondary Hue Max"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_sHueMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="360" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sHueMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Secondary Hue Min"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_sHueMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="360" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sHueMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Secondary Saturation Max"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_sSatMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sSatMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Secondary Saturation Min"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_sSatMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sSatMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Secondary Brightness Max"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_sBrightMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sBrightMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Secondary Brightness Min"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_sBrightMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9\.]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="1" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sBrightMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                    </StackPanel>
+
+                    <!---->
+
+                    <CheckBox Content="Secondary RGB Filter"
+                                  ToolTip="Use(and reveal) secondary filter based on RGB colour values" Margin="5,5"
+                                  IsChecked="{Binding SettingsViewModel.CF_useSecondaryRGB, Mode=TwoWay}" />
+                    <StackPanel  Visibility="{Binding Path=SettingsViewModel.CF_useSecondaryRGB, Converter={StaticResource BoolToVis}}">
+
+                        <Label Content="Secondary Red Max"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_sRMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sRMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Secondary Red Min"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_sRMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sRMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+
+                        <Label Content="Secondary Green Max"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_sGMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sGMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Secondary Green Min"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_sGMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sGMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+
+                        <Label Content="Secondary Blue Max"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_sBMax, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sBMax, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                        <Label Content="Secondary Blue Min"></Label>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="7*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBox Text="{Binding SettingsViewModel.CF_sBMin, Mode=TwoWay, Delay=250, UpdateSourceTrigger=PropertyChanged}"
+                                 components:NumericOnlyEntry.RegexFilter="^[0-9]+$"
+                                 VerticalAlignment="Top" />
+                            <Slider Grid.Column="1" Minimum="0" Maximum="255" Margin="10,10" VerticalAlignment="Center" Value="{Binding SettingsViewModel.CF_sBMin, Mode=TwoWay, Delay=200, UpdateSourceTrigger=PropertyChanged}"></Slider>
+                        </Grid>
+                    </StackPanel>
+
+                    <!---->
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition/>
+                            <ColumnDefinition/>
+                        </Grid.ColumnDefinitions>
+
+                        
+                        <StackPanel Grid.Column="1">
+                            <Label MouseLeftButtonDown="ShowUnfiltered"
+                                Padding="5"
+                                DockPanel.Dock="Right"
+                                Content="Show Unfiltered"
+                                FontWeight="Regular"
+                                Style="{StaticResource Label_Button}" />
+                            <Label MouseLeftButtonDown="ApplyFilter"
+                                Padding="5"
+                                DockPanel.Dock="Right"
+                                Content="Apply Filter"
+                                FontWeight="Regular"
+                                Grid.Column="1"
+                                Style="{StaticResource Label_Button}" />
+                        </StackPanel>
+                        <StackPanel Grid.Column="0">
+                            <Label MouseLeftButtonDown="LoadLatest"
+                                Padding="5"
+                                DockPanel.Dock="Right"
+                                Content="Load Last Use"
+                                FontWeight="Regular"
+                                Style="{StaticResource Label_Button}" />
+                            <Label MouseLeftButtonDown="LoadFromFile"
+                                Padding="5"
+                                DockPanel.Dock="Right"
+                                Content="Load From File"
+                                FontWeight="Regular"
+                                Style="{StaticResource Label_Button}" />
+                        </StackPanel>
+                    </Grid>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+    </Grid>
+</Window>

--- a/WFInfo/Settings/ThemeAdjuster.xaml.cs
+++ b/WFInfo/Settings/ThemeAdjuster.xaml.cs
@@ -1,0 +1,175 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Ionic.Zip;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using System.Drawing;
+using System.Windows.Media.Imaging;
+using System.Windows.Forms;
+using System.Threading.Tasks;
+
+namespace WFInfo
+{
+    /// <summary>
+    /// Interaction logic for verifyCount.xaml
+    /// </summary>
+    public partial class ThemeAdjuster : Window
+    {
+        private readonly Settings.SettingsViewModel _viewModel;
+        public Settings.SettingsViewModel SettingsViewModel => _viewModel;
+
+        public static ThemeAdjuster INSTANCE;
+        private Bitmap unfiltered;
+        public BitmapImage displayImage;
+
+        public ThemeAdjuster()
+        {
+            InitializeComponent();
+            DataContext = this;
+            INSTANCE = this;
+            _viewModel = Settings.SettingsViewModel.Instance;
+        }
+        public static void ShowThemeAdjuster()
+        {
+            if (INSTANCE != null)
+            {
+                INSTANCE.Show();
+                INSTANCE.Focus();
+            }
+        }
+
+        private static BitmapImage BitmapToImageSource(Bitmap bitmap)
+        {
+            //from https://stackoverflow.com/questions/22499407/how-to-display-a-bitmap-in-a-wpf-image
+            using (MemoryStream memory = new MemoryStream())
+            {
+                bitmap.Save(memory, System.Drawing.Imaging.ImageFormat.Bmp);
+                memory.Position = 0;
+                BitmapImage bitmapimage = new BitmapImage();
+                bitmapimage.BeginInit();
+                bitmapimage.StreamSource = memory;
+                bitmapimage.CacheOption = BitmapCacheOption.OnLoad;
+                bitmapimage.EndInit();
+
+                return bitmapimage;
+            }
+        }
+
+        private void ApplyFilter(object sender, RoutedEventArgs e)
+        {
+            if (unfiltered != null)
+            {
+                Bitmap filtered = OCR.ScaleUpAndFilter(unfiltered, WFtheme.CUSTOM, out int[] rowHits, out int[] colHits);
+                displayImage = BitmapToImageSource(filtered);
+                previewImage.Source = displayImage;
+                filtered.Dispose();
+            }
+        }
+
+        private void ShowUnfiltered(object sender, RoutedEventArgs e)
+        {
+            if (unfiltered != null)
+            {
+                displayImage = BitmapToImageSource(unfiltered);
+                previewImage.Source = displayImage;
+            }
+        }
+
+        private void LoadLatest(object sender, RoutedEventArgs e)
+        {
+            List<FileInfo> files = (new DirectoryInfo(Main.AppPath + @"\Debug\")).GetFiles()
+                .Where(f => f.Name.Contains("FullScreenShot"))
+                .ToList();
+            files = files.OrderBy(f => f.CreationTimeUtc).ToList();
+
+
+            Bitmap image = null;
+            try
+            {
+                foreach (FileInfo file in files)
+                {
+                    Main.AddLog("Loading filter testing with file: " + file.Name);
+
+                    //Get the path of specified file
+                    image = new Bitmap(file.FullName);
+                    break;
+                }
+            }
+            catch (Exception exc)
+            {
+                Main.AddLog(exc.Message);
+                Main.AddLog(exc.StackTrace);
+                Main.StatusUpdate("Failed to load image", 1);
+            }
+            if (image != null)
+            {
+                unfiltered = image;
+            }
+
+        }
+        private void LoadFromFile(object sender, RoutedEventArgs e)
+        {
+            // Using WinForms for the openFileDialog because it's simpler and much easier
+            using (OpenFileDialog openFileDialog = new OpenFileDialog())
+            {
+                openFileDialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+                openFileDialog.Filter = "image files (*.png)|*.png|All files (*.*)|*.*";
+                openFileDialog.FilterIndex = 2;
+                openFileDialog.RestoreDirectory = true;
+                openFileDialog.Multiselect = true;
+
+                if (openFileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                {
+                    Task.Factory.StartNew(
+                        () =>
+                        {
+
+                            Bitmap image = null;
+                            try
+                            {
+                                foreach (string file in openFileDialog.FileNames)
+                                {
+                                        Main.AddLog("Loading filter testing with file: " + file);
+
+                                        //Get the path of specified file
+                                        image = new Bitmap(file);
+                                    break;
+                                }
+                            }
+                            catch (Exception exc)
+                            {
+                                Main.AddLog(exc.Message);
+                                Main.AddLog(exc.StackTrace);
+                                Main.StatusUpdate("Failed to load image", 1);
+                            }
+                            if (image != null)
+                            {
+                                unfiltered = image;
+                            }
+                        });
+                }
+                else
+                {
+                    Main.StatusUpdate("Failed to load image", 1);
+                }
+            }
+        }
+
+        private void Hide(object sender, RoutedEventArgs e)
+        {
+            Hide();
+        }
+
+        // Allows the draging of the window
+        private new void MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ChangedButton == MouseButton.Left)
+                DragMove();
+        }
+    }
+}

--- a/WFInfo/Settings/ThemeAdjuster.xaml.cs
+++ b/WFInfo/Settings/ThemeAdjuster.xaml.cs
@@ -162,6 +162,13 @@ namespace WFInfo
 
         private void Hide(object sender, RoutedEventArgs e)
         {
+            if (unfiltered != null)
+            {
+                unfiltered.Dispose();
+            }
+            unfiltered = null;
+            displayImage = null;
+            previewImage.Source = null;
             Hide();
         }
 


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
- Closes #144 - "Auto Add" (internally Auto Count) feature
- Adds ability to override theme choice, and a custom filter option
- Better logging of auto-list
- Better reward overlay location for 1 and 2 reward options
- Removed some unused code
- Checks for game getting restarted if original instance closes
  - This also fixes WFM status getting locked to "invisible" if the game gets closed
- Adds "Auto CSV", ability to log reward options and reward choice into a CSV file

---

### Reproduction steps

If you'd rather have me walk you through some/all of these on discord, just @ me
#### Auto Add
1. Enable "Auto Add" in settings (requires Auto)
2. Run fissure
3. Wait for reward screen to end
4. Window opens showing list of rewards from current session
    - Has ComboBox for selecting a different reward from the same reward screen
    - Has increment/dismiss buttons for each reward
    - Has increment/dismiss buttons for all shown rewards

#### Auto CSV
1. Enable "Auto CSV" in settings (requires Auto)
2. Run fissure
3. Wait for reward screen to end
4. Check `%appdata%/WFInfo` for the file `rewardExport.csv`

#### Theme override
1. Open WFInfo settings
2. Change "Theme" option
3. All scanning uses your chosen theme for filtering
   - "AUTO" uses the results from the automatic theme detection
   - Both "CUSTOM" and "UNKNOWN" uses the custom theme (see next section)

#### Custom Theme 
1. Open WFInfo settings
2. Click cog between "Theme" and its combobox
3. Click "Load Last Use" or "Load From File" buttons to load a test image
4. Click "Show Unfiltered" to preview test image
5. Enable and adjust the filter options
   - A pixel passes the custom filter if it passes any of the individual enabled filters
   - A pixel passes the individual filter if all parameters are within their relevant min and max values
   - The sliders and textboxes have a delay before applying, to not write to disk unnecessarily fast
7. Click "Apply Filter" to see the filter output when applied to your test image
   -  Custom theme can't be selected by the automatic theme detection

#### Better logging of auto-list
1. See `LogChanged` method in `Data.cs` and/or log file after reward screen with auto-list/auto-add/auto-csv enabled

#### Game restart detection
1. Start game and WFInfo
2. Close game
3. Restart game
   - Close is only detected by AFK loop (once a minute, if logged in with WFM) or anything triggering `VerifyWarframe`. If not logged in with WFM, this basically requires a manual activation attempt
4. See if WFInfo is behaving as if the game is actually running
5. If logged in with WFM, see if online status sets itself back to offline/invisible when changed (either through website or WFInfo)

#### Overlay location for 1/2 rewards
1. Set display mode to Overlay
2. Run relic with only corresponding amount of players successfully opening relic
   - In the case of 1 reward, requires more than 1 player, with only 1 player getting enough traces
3. See overlay location

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix/Feature/Enhancement/]**
