### PR TITLE
Fixed auto delay for manual theme selection (file-only setting)

### DIFF
--- a/WFInfo/Data.cs
+++ b/WFInfo/Data.cs
@@ -1158,19 +1158,28 @@ namespace WFInfo
                 var watch = Stopwatch.StartNew();
                 long stop = watch.ElapsedMilliseconds + 5000;
                 long wait = watch.ElapsedMilliseconds;
+                long fixedStop = watch.ElapsedMilliseconds + ApplicationSettings.GlobalReadonlySettings.FixedAutoDelay;
 
                 OCR.UpdateWindow();
 
-                while (watch.ElapsedMilliseconds < stop)
+                if (ApplicationSettings.GlobalReadonlySettings.ThemeSelection == WFtheme.AUTO)
                 {
-                    if (watch.ElapsedMilliseconds <= wait) continue;
-                    wait += ApplicationSettings.GlobalReadonlySettings.AutoDelay;
-                    OCR.GetThemeWeighted(out double diff);
-                    if (!(diff > 40)) continue;
-                    while (watch.ElapsedMilliseconds < wait) ;
-                    Main.AddLog("started auto processing");
+                    while (watch.ElapsedMilliseconds < stop)
+                    {
+                        if (watch.ElapsedMilliseconds <= wait) continue;
+                        wait += ApplicationSettings.GlobalReadonlySettings.AutoDelay;
+                        OCR.GetThemeWeighted(out double diff);
+                        if (!(diff > 40)) continue;
+                        while (watch.ElapsedMilliseconds < wait) ;
+                        Main.AddLog("started auto processing");
+                        OCR.ProcessRewardScreen();
+                        break;
+                    }
+                } else
+                {
+                    while (watch.ElapsedMilliseconds < fixedStop) ;
+                    Main.AddLog("started auto processing (fixed delay)");
                     OCR.ProcessRewardScreen();
-                    break;
                 }
                 watch.Stop();
             }

--- a/WFInfo/Settings/ApplicationSettings.cs
+++ b/WFInfo/Settings/ApplicationSettings.cs
@@ -113,6 +113,7 @@ namespace WFInfo.Settings
         public int CF_sGMin { get; set; } = 0;
         public int CF_sBMax { get; set; } = 255;
         public int CF_sBMin { get; set; } = 0;
+        public long FixedAutoDelay { get; set; } = 2000L;
         public string Ignored { get; set; } = null;
         [OnError]
         internal void OnError(StreamingContext context, ErrorContext errorContext)

--- a/WFInfo/Settings/IReadOnlyApplicationSettings.cs
+++ b/WFInfo/Settings/IReadOnlyApplicationSettings.cs
@@ -87,6 +87,7 @@ namespace WFInfo.Settings
         int CF_sGMin { get; }
         int CF_sBMax { get; }
         int CF_sBMin { get; }
+        long FixedAutoDelay { get; }
         string Ignored { get; }
     }
 }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
- Auto-trigger now has a fixed delay if theme is manually selected
   - This delay can be modified via the settings file, with the entry `FixedAutoDelay` (in milliseconds). I decided not to put it in the UI at this time, but if it turns out to frequently need adjustment I'll do that.
---

### Reproduction steps

1. Enable Auto-trigger
2. Add some condition that'd make the best theme confidence below 40, for example colourblind mode
3. Select and tune custom theme for those conditions
    - If the filter for one of the existing themes work, that's also applicable
4. Run a fissure, see if Auto-trigger works


---

### Evidence/screenshot/link to line

[Fixed delay length can be found here](https://github.com/D1firehail/WFinfo/blob/99d1dad98cacc5b56b9fe1813e2871dfba9efb2d/WFInfo/Settings/ApplicationSettings.cs#L116). 2 seconds felt like an appropriate default, long enough to have some margin but not excessively so. 

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
