### PR TITLE
Fix Naive URL name approach

### DIFF
--- a/WFInfo/Data.cs
+++ b/WFInfo/Data.cs
@@ -1408,8 +1408,10 @@ namespace WFInfo
         {
             foreach (var marketItem in marketItems)
             {
-                if (marketItem.Value.ToString().Contains(primeItem))
+                if (marketItem.Value.ToString().Split('|').First().Equals(primeItem, StringComparison.OrdinalIgnoreCase))
+                {
                     return marketItem.Key;
+                }
             }
             throw new Exception($"PrimeItemToItemID, Prime item \"{primeItem}\" does not exist in marketItem");
         }
@@ -1489,7 +1491,15 @@ namespace WFInfo
 
         public string GetUrlName(string primeName)
         {
-            return primeName.ToLower(Main.culture).Replace(' ', '_'); //seems to work for now but might need to be changed.
+            foreach (var marketItem in marketItems)
+            {
+                string[] vals = marketItem.Value.ToString().Split('|');
+                if (vals.Length > 2 && vals[0].Equals(primeName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return vals[1];
+                }
+            }
+            throw new Exception($"GetUrlName, Prime item \"{primeName}\" does not exist in marketItem");
         }
 
         /// <summary>


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Fixed issue where certain items would crash search-it

---

### Reproduction steps
1. Start search-it
2. Search for `Baruuk Prime Chassis`
3. Without fix: freeze/crash. With fix: works as expected

---

### Evidence/screenshot/link to line

It's in the one block of code that's been changed

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
