### PR TITLE
Max upload fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If you really like this software, you even can post a review on the devs profile
 
 **Kekasi:** u/RandomFacades (Reddit), Kekasi (Warframe), Kek#5390 (Discord)
 
-**Dapal-003:** u/Dapal-003 (Reddit), Dapal003 (Warframe), ダパール・Dapal-003#0001 (Discord)
+**Dapal-003:** u/Dapal-003 (Reddit), Dapal003 (Warframe), ダパール・Dapal-003#0695 (Discord)
 
 **Dimon222:** u/dimon222 (Reddit), dimon222 (Warframe), dimon222#8256 (Discord)
 

--- a/WFInfo/errorDialogue.xaml.cs
+++ b/WFInfo/errorDialogue.xaml.cs
@@ -91,7 +91,7 @@ namespace WFInfo
                     
                     zip.AddFile(startPath + @"\..\debug.log", "");
                     zip.Comment = "This zip was created at " + closest.ToString("yyyy-MM-dd_HH-mm-ssff");
-                    zip.MaxOutputSegmentSize64 = 8000 * 1024; // 8m segments
+                    zip.MaxOutputSegmentSize64 = 25000 * 1024; // 8m segments
                     zip.Save(fullZipPath + ".zip");
                 }
             }


### PR DESCRIPTION
### What did you fix?
Discord changed it's max default upload size from a measly 8mb to a measly 25mb. This will slash the amount of zip files a user has to upload in third if the archive is large. Also a small change to the read-me with updated discord tag


---

### Reproduction steps
N/A

---

### Evidence/screenshot/link to line

N/A

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Enhancement/Docs**
