### PR TITLE
Bump version, fix win10 pre HDR sdk, add WFM cache reuse

### DIFF
--- a/WFInfo/Data.cs
+++ b/WFInfo/Data.cs
@@ -247,7 +247,14 @@ namespace WFInfo
                     }
                 }
             }
-            ReloadItems();
+            try
+            {
+                ReloadItems();
+            }
+            catch
+            {
+                Main.AddLog("Failed to refresh items from warframe.market, skipping WFM update for now. Some items might have incomplete info.");
+            }
             marketData = new JObject();
             WebClient webClient = CustomEntrypoint.createNewWebClient();
             JArray rows = JsonConvert.DeserializeObject<JArray>(webClient.DownloadString(sheetJsonUrl));

--- a/WFInfo/Main.cs
+++ b/WFInfo/Main.cs
@@ -92,8 +92,8 @@ namespace WFInfo
 
             services.AddGDIScreenshots();
 
-            // Only add windows capture on supported plarforms (W10+)
-            if (ApiInformation.IsTypePresent("Windows.Graphics.Capture.GraphicsCaptureSession"))
+            // Only add windows capture on supported plarforms (W10+ 2004 / Build 20348 and above)
+            if (ApiInformation.IsTypePresent("Windows.Graphics.Capture.GraphicsCaptureSession") && ApiInformation.IsPropertyPresent("Windows.Graphics.Capture.GraphicsCaptureSession", "IsBorderRequired"))
             {
                 services.AddWindowsCaptureScreenshots();
             }

--- a/WFInfo/Properties/AssemblyInfo.cs
+++ b/WFInfo/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("9.6.1.0")]
-[assembly: AssemblyFileVersion("9.6.1.0")]
+[assembly: AssemblyVersion("9.6.2.0")]
+[assembly: AssemblyFileVersion("9.6.2.0")]

--- a/WFInfo/WFInfo.csproj
+++ b/WFInfo/WFInfo.csproj
@@ -73,7 +73,7 @@
     <Content Include="FodyWeavers.xsd" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autoupdater.NET.Official" Version="1.8.3" />
+    <PackageReference Include="Autoupdater.NET.Official" Version="1.8.4" />
     <PackageReference Include="Costura.Fody" Version="5.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -84,7 +84,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -102,7 +102,7 @@
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Tesseract" Version="5.2.0" />
     <PackageReference Include="WebSocketSharp-netstandard" Version="1.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="7.0.8" /> 
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="7.0.12" /> 
   </ItemGroup>
   <ItemGroup>
     <None Update="$(HOME)\.nuget\packages\tesseract\5.2.0\build\\..\x64\leptonica-1.82.0.dll">


### PR DESCRIPTION
* Fix proper fallback for pre-HDR sdk Win 10 builds
* Add WFM cache reuse if its down
* Bump version to new release 9.6.2