### PR TITLE
Fix CPU-readable copy of screenshot texture not being disposed

### DIFF
--- a/WFInfo/Services/Screenshot/WindowsCaptureScreenshotService.cs
+++ b/WFInfo/Services/Screenshot/WindowsCaptureScreenshotService.cs
@@ -86,6 +86,7 @@ namespace WFInfo.Services.Screenshot
             else bitmap = CaptureSdr(sdrSpan, width, height, mapSource.RowPitch);
 
             _d3dDevice.ImmediateContext.UnmapSubresource(cpuTexture, 0);
+            cpuTexture.Dispose();
 
             var result = new List<Bitmap> { bitmap };
             return Task.FromResult(result);


### PR DESCRIPTION
### What did you fix?

A copy of the screenshot texture (in windows capture) was not being freed after creating a bitmap for further processing. This led to shared GPU memory slowly running out until WFInfo would crash. This PR properly disposes of said texture.