### PR TITLE
Fix WFMarket timeout streaming check

### DIFF
--- a/WFInfo/Main.cs
+++ b/WFInfo/Main.cs
@@ -166,7 +166,7 @@ namespace WFInfo
         }
         private async void TimeoutCheck()
         {
-            if (!await dataBase.IsJWTvalid().ConfigureAwait(true) || !_process.GameIsStreamed)
+            if (!await dataBase.IsJWTvalid().ConfigureAwait(true) || _process.GameIsStreamed)
                 return;
             DateTime now = DateTime.UtcNow;
             Debug.WriteLine($"Checking if the user has been inactive \nNow: {now}, Lastactive: {latestActive}");


### PR DESCRIPTION
### What did you fix?
WFMarket timeout detection only runs when the game is being streamed, but instead it should run when the game is **not** being streamed.
This fixes automatic WFMarket status updates not working for most users.

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**