### PR TITLE
Fix Left/Right arrow keys also being read as mouse keys

### DIFF
--- a/WFInfo/Settings/ApplicationSettings.cs
+++ b/WFInfo/Settings/ApplicationSettings.cs
@@ -48,7 +48,20 @@ namespace WFInfo.Settings
         [JsonIgnore]
         public Key? ActivationKeyKey => Enum.TryParse<Key>(ActivationKey, out var res) ? res : (Key?)null;
         [JsonIgnore]
-        public MouseButton? ActivationMouseButton => Enum.TryParse<MouseButton>(ActivationKey, out var res) ? res : (MouseButton?)null;
+        public MouseButton? ActivationMouseButton 
+        { 
+            get 
+            { 
+                var result = Enum.TryParse<MouseButton>(ActivationKey, out var res) ? res : (MouseButton?)null; 
+                if (result is MouseButton.Left || result is MouseButton.Right)
+                {
+                    // Prevent Key.Left and Key.Right (arrow keys) from being misinterpreted as the mouse buttons.
+                    // Using these mouse buttons as activation key is a bad idea anyway
+                    return null;
+                }
+                return result;
+            }
+        }
         public Key DebugModifierKey { get; set; } = Key.LeftShift;
         public Key SearchItModifierKey { get; set; } = Key.OemTilde;
         public Key SnapitModifierKey { get; set; } = Key.LeftCtrl;


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Fix Left/Right arrow keys being used as Activation Key also making Left/Right mouse keys being considered as Activation Key

---

### Reproduction steps
1. Set the Left or RIght arrow keys as your activation key
2. Press Left or Right mouse key

---

### Evidence/screenshot/link to line

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix**
