### PR TITLE
Improve theme selector safeguard, Restore Pre-HDR PR behaviour of debug setting

### DIFF
--- a/WFInfo/LowLevelListener.cs
+++ b/WFInfo/LowLevelListener.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Windows;
 using System.Windows.Input;
+using System.Windows.Threading;
 
 namespace WFInfo
 {
@@ -107,12 +109,14 @@ namespace WFInfo
 
         protected static void OnKeyAction(Key key)
         {
-            KeyEvent?.Invoke(key);
+            // Bounce via InvokeAsync, to avoid being in an "input-synchronous call" state which can cause crash on certain actions
+            Application.Current.Dispatcher.InvokeAsync(() => { KeyEvent?.Invoke(key); });
         }
 
         protected static void OnMouseAction(MouseButton key)
         {
-            MouseEvent?.Invoke(key);
+            // Bounce via InvokeAsync, to avoid being in an "input-synchronous call" state which can cause crash on certain actions
+            Application.Current.Dispatcher.InvokeAsync(() => { MouseEvent?.Invoke(key); });
         }
 
         private static IntPtr HookCallbackM(int nCode, IntPtr wParam, IntPtr lParam) //handels mouse input

--- a/WFInfo/Main.cs
+++ b/WFInfo/Main.cs
@@ -337,6 +337,11 @@ namespace WFInfo
                 StatusUpdate("Starting master it", 0);
                 Task.Factory.StartNew(() => {
                     Bitmap bigScreenshot = OCR.CaptureScreenshot();
+                    if (bigScreenshot == null)
+                    {
+                        AddLog("MasterIt activation failed: Screenshot failed");
+                        return;
+                    }
                     OCR.ProcessProfileScreen(bigScreenshot);
                     bigScreenshot.Dispose();
                 });

--- a/WFInfo/Services/Screenshot/GdiScreenshotService.cs
+++ b/WFInfo/Services/Screenshot/GdiScreenshotService.cs
@@ -2,17 +2,22 @@
 using System.Drawing;
 using System.Threading.Tasks;
 using WFInfo.Services.WindowInfo;
+using WFInfo.Settings;
 
 namespace WFInfo.Services.Screenshot
 {
     public class GdiScreenshotService : IScreenshotService
     {
         private static IWindowInfoService _window;
+        private static IReadOnlyApplicationSettings _settings;
 
-        public GdiScreenshotService(IWindowInfoService window) 
+        public GdiScreenshotService(IWindowInfoService window, IReadOnlyApplicationSettings settings) 
         {
             _window = window;
+            _settings = settings;
         }
+
+        public bool IsAvailable => true;
 
         public Task<List<Bitmap>> CaptureScreenshot()
         {
@@ -24,9 +29,16 @@ namespace WFInfo.Services.Screenshot
             int width = window.Width;
             int height = window.Height;
 
-            if (window == null || window.Width == 0 || window.Height == 0)
+            if (width == 0 || height == 0)
             {
+                if (!_settings.Debug) 
+                {
+                    return Task.FromResult(new List<Bitmap>());
+                }
+
                 window = _window.Screen.Bounds;
+                width = window.Width;
+                height = window.Height;
                 center = new Point(window.X + window.Width / 2, window.Y + window.Height / 2);
 
                 width *= (int)_window.DpiScaling;

--- a/WFInfo/Services/Screenshot/IScreenshotService.cs
+++ b/WFInfo/Services/Screenshot/IScreenshotService.cs
@@ -21,5 +21,7 @@ namespace WFInfo.Services.Screenshot
         /// </summary>
         /// <returns>Captured screenshots</returns>
         Task<List<Bitmap>> CaptureScreenshot();
+
+        bool IsAvailable { get; }
     }
 }

--- a/WFInfo/Services/Screenshot/ImageScreenshotService.cs
+++ b/WFInfo/Services/Screenshot/ImageScreenshotService.cs
@@ -9,6 +9,8 @@ namespace WFInfo.Services.Screenshot
 {
     public class ImageScreenshotService : IScreenshotService
     {
+        public bool IsAvailable => true;
+
         public async Task<List<Bitmap>> CaptureScreenshot()
         {
             // Using WinForms for the openFileDialog because it's simpler and much easier

--- a/WFInfo/Services/Screenshot/WindowsCaptureScreenshotService.cs
+++ b/WFInfo/Services/Screenshot/WindowsCaptureScreenshotService.cs
@@ -47,8 +47,15 @@ namespace WFInfo.Services.Screenshot
             _process.OnProcessChanged += CreateCaptureSession;
         }
 
+        public bool IsAvailable { get; private set; }
+
         public Task<List<Bitmap>> CaptureScreenshot()
         {
+            if (!IsAvailable)
+            {
+                return Task.FromResult(new List<Bitmap>());
+            }
+
             Texture2D cpuTexture = null;
             int width, height;
 
@@ -96,6 +103,14 @@ namespace WFInfo.Services.Screenshot
         {
             _session?.Dispose();
             _framePool?.Dispose();
+            _session = null;
+            _framePool = null;
+
+            IsAvailable = process != null;
+            if (!IsAvailable)
+            {
+                return;
+            }
 
             _item = CaptureHelper.CreateItemForWindow(process.MainWindowHandle);
             _framePool = Direct3D11CaptureFramePool.CreateFreeThreaded(_device, pixelFormat, 2, _item.Size);

--- a/WFInfo/Services/WarframeProcess/WarframeProcessFinder.cs
+++ b/WFInfo/Services/WarframeProcess/WarframeProcessFinder.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using WFInfo.Settings;
@@ -65,8 +66,6 @@ namespace WFInfo.Services.WarframeProcess
                     try
                     {
                         bool _ = _warframe.HasExited;
-                        OnProcessChanged?.Invoke(_warframe);
-                        return;
                     }
                     catch (System.ComponentModel.Win32Exception e)
                     {
@@ -75,16 +74,9 @@ namespace WFInfo.Services.WarframeProcess
                         Main.AddLog($"Failed to get Warframe process due to: {e.Message}");
                         Main.StatusUpdate("Restart Warframe without admin privileges", 1);
 
-                        // Substitute process for debug purposes
-                        if (_settings.Debug)
-                        {
-                            Main.AddLog($"Substituting Warframe process with WFInfo process for debug purposes.");
-                            _warframe = Process.GetCurrentProcess();
-                        }
-
-                        OnProcessChanged?.Invoke(_warframe);
-                        return;
                     }
+                    OnProcessChanged?.Invoke(_warframe);
+                    return;
                 }
                 else if (process.MainWindowTitle.Contains("Warframe") && process.MainWindowTitle.Contains("GeForce NOW"))
                 {
@@ -100,8 +92,6 @@ namespace WFInfo.Services.WarframeProcess
                     try
                     {
                         bool _ = _warframe.HasExited;
-                        OnProcessChanged?.Invoke(_warframe);
-                        return;
                     }
                     catch (System.ComponentModel.Win32Exception e)
                     {
@@ -110,16 +100,9 @@ namespace WFInfo.Services.WarframeProcess
                         Main.AddLog($"Failed to get Warframe process due to: {e.Message}");
                         Main.StatusUpdate("Restart Warframe without admin privileges, or WFInfo with admin privileges", 1);
 
-                        // Substitute process for debug purposes
-                        if (_settings.Debug)
-                        {
-                            Main.AddLog($"Substituting Warframe process with WFInfo process for debug purposes.");
-                            _warframe = Process.GetCurrentProcess();
-                        }
-
-                        OnProcessChanged?.Invoke(_warframe);
-                        return;
                     }
+                    OnProcessChanged?.Invoke(_warframe);
+                    return;
                 }
             }
 
@@ -127,17 +110,6 @@ namespace WFInfo.Services.WarframeProcess
             {
                 Main.AddLog("Did Not Detect Warframe Process");
                 Main.StatusUpdate("Unable to Detect Warframe Process", 1);
-            }
-            else
-            {
-                // Substitute process for debug purposes
-                if (_settings.Debug)
-                {
-                    Main.AddLog($"Substituting Warframe process with WFInfo process for debug purposes.");
-                    _warframe = Process.GetCurrentProcess();
-                }
-
-                OnProcessChanged?.Invoke(_warframe);
             }
         }
     }

--- a/WFInfo/Services/WindowInfo/Win32WindowInfoService.cs
+++ b/WFInfo/Services/WindowInfo/Win32WindowInfoService.cs
@@ -8,7 +8,7 @@ namespace WFInfo.Services.WindowInfo
 {
     public class Win32WindowInfoService : IWindowInfoService
     {
-        public double DpiScaling { get; private set; }
+        public double DpiScaling { get; private set; } = 1;
         public double ScreenScaling 
         { 
             get

--- a/WFInfo/Settings/SettingsViewModel.cs
+++ b/WFInfo/Settings/SettingsViewModel.cs
@@ -411,10 +411,32 @@ namespace WFInfo.Settings
             get => _settings.ThemeSelection;
             set
             {
+                if (_settings.ThemeSelection == value)
+                {
+                    return;
+                }
+
+                // No need to verify intent when switching to AUTO
+                if (value != WFtheme.AUTO && !ConfirmThemeChangeIntentional(_settings.ThemeSelection, value))
+                {
+                    return;
+                }
+
                 _settings.ThemeSelection = value;
                 RaisePropertyChanged();
             }
         }
+
+        private bool ConfirmThemeChangeIntentional(WFtheme oldTheme, WFtheme newTheme)
+        {
+            MessageBoxResult messageBoxResult = MessageBox.Show("You are about to force WFInfo to think you're using the " + newTheme + " theme in-game." + Environment.NewLine + Environment.NewLine
+                + "If this is wrong, WFInfo will not be able to do its job." + Environment.NewLine + Environment.NewLine
+                + "We STRONGLY recommend setting this to AUTO." + Environment.NewLine + Environment.NewLine
+                + "Are you sure?",
+                "Change of target theme", MessageBoxButton.OKCancel);
+            return messageBoxResult == MessageBoxResult.OK;
+        }
+
         public bool CF_usePrimaryHSL { get => _settings.CF_usePrimaryHSL;
             set 
             {

--- a/WFInfo/Settings/SettingsWindow.xaml
+++ b/WFInfo/Settings/SettingsWindow.xaml
@@ -433,7 +433,7 @@
                                           BorderBrush="#FF0F0F0F"
                                           ItemsSource="{Binding Source={StaticResource enumWFTheme}}"
                                           SelectedItem="{Binding SettingsViewModel.ThemeSelection}"
-                                          Margin="5,4" Template="{DynamicResource ComboBoxTemplate}" Style="{DynamicResource ComboBoxStyle1}" DropDownClosed="ThemeSelectionComboBox_OnDropDownClosed"/>
+                                          Margin="5,4" Template="{DynamicResource ComboBoxTemplate}" Style="{DynamicResource ComboBoxStyle1}" SelectionChanged="themeSelectionComboBox_SelectionChanged"/>
 
                             <Label Visibility="{Binding SettingsViewModel.OsSupportsHDR, Converter={StaticResource BoolVisibilityConverter}}" Content="HDR" Grid.Column="0" Grid.Row="1"/>
                             <Label Visibility="{Binding SettingsViewModel.OsSupportsHDR, Converter={StaticResource BoolVisibilityConverter}}" Grid.Row="1" Grid.Column="1" ToolTip="Auto - Detect based on game settings&#x0a;On - Always use HDR capture (will slightly change colors) &#x0a;Off - Always use SDR capture (will result in overblown HDR screenshots) &#x0a;&#x0a;It is recommended to use a custom theme with HDR enabled, this mode only compresses the dynamic color range." Margin="0,5,10,5" Padding="3"  HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Height="20" VerticalAlignment="Top" HorizontalAlignment="Right" Width="20">

--- a/WFInfo/Settings/SettingsWindow.xaml.cs
+++ b/WFInfo/Settings/SettingsWindow.xaml.cs
@@ -266,9 +266,13 @@ namespace WFInfo.Settings
             ThemeAdjuster.ShowThemeAdjuster();
         }
 
-        private void ThemeSelectionComboBox_OnDropDownClosed(object sender, EventArgs e)
+        private void themeSelectionComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            MessageBoxResult messageBoxResult = MessageBox.Show("This option will not change WFInfo screen style. It will force app to think you have selected this theme in Warframe (and will use its pixel colors for item scanning). Unless you know what you're doing, leave Auto selected.", "Change of target theme", System.Windows.MessageBoxButton.OK);
+            // mismatch only occurs if we intentionally suppress the change in the viewmodel. If that happens, reset selected value
+            if ((WFtheme)themeSelectionComboBox.SelectedValue != SettingsViewModel.ThemeSelection)
+            {
+                themeSelectionComboBox.SelectedValue = SettingsViewModel.ThemeSelection;
+            }
         }
     }
 }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
- Improve safeguard of theme selector setting. Previously, it gave a warning on closing dropdown. Now, it reacts on actual selection and gives an option to cancel.
- Bounce mouse and keyboard callbacks via Dispatcher InvokeAsync to prevent crash. Possibly specific to debug mode and/or game not running.
- Restore old behaviour of debug flag, making it grab entire primary screen if the game process is closed.
- Allow CaptureScreenshot method to fail, and add safeguards in case it fails. It could previously happen due to game closing mid-activation or by using snap-it or master-it with game closed and debug mode off.

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix/Enhancement]**
