### PR TITLE
Delay start of find process timer by 25 seconds

### DIFF
--- a/WFInfo/Services/WarframeProcess/WarframeProcessFinder.cs
+++ b/WFInfo/Services/WarframeProcess/WarframeProcessFinder.cs
@@ -72,7 +72,7 @@ namespace WFInfo.Services.WarframeProcess
         public WarframeProcessFinder(IReadOnlyApplicationSettings settings)
         {
             _settings = settings;
-            find_process_timer = new System.Threading.Timer(FindProcess, null, 0, 40000);
+            find_process_timer = new System.Threading.Timer(FindProcess, null, 25000, 40000);
         }
 
         private void FindProcess(Object stateInfo)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the timing for the process-finding operation, delaying the first execution by 25 seconds to improve performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->