### PR TITLE
Some bug fixes and maintenance

### DIFF
--- a/WFInfo/CustomEntrypoint.cs
+++ b/WFInfo/CustomEntrypoint.cs
@@ -47,8 +47,6 @@ namespace WFInfo
         private static string tesseract_hotlink_platform_specific_prefix;
         private static readonly string app_data_tesseract_catalog = appPath + @"\" + tesseract_version_folder;
 
-        public static readonly string appdata_tessdata_folder = appPath + @"\tessdata";
-
         private static readonly InitialDialogue dialogue = new InitialDialogue();
         public static CancellationTokenSource stopDownloadTask;
         public static string build_version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
@@ -101,24 +99,11 @@ namespace WFInfo
             Directory.CreateDirectory(app_data_tesseract_catalog + @"\x86");
             Directory.CreateDirectory(app_data_tesseract_catalog + @"\x64");
 
-            Directory.CreateDirectory(appdata_tessdata_folder);
+            // TrainedData folder/content handled by TesseractService
 
             cleanLegacyTesseractIfNeeded();
             CollectDebugInfo();
             tesseract_hotlink_platform_specific_prefix = tesseract_hotlink_prefix;
-
-            // Refresh traineddata structure
-            // This is temporary, to be removed in half year from now
-            if (File.Exists(appdata_tessdata_folder + @"\engbest.traineddata"))
-            {
-                // To avoid conflicts for folks who like to experiment...
-                if (File.Exists(appdata_tessdata_folder + @"\en.traineddata"))
-                {
-                    File.Delete(appdata_tessdata_folder + @"\en.traineddata");
-                }
-                File.Move(appdata_tessdata_folder + @"\engbest.traineddata", appdata_tessdata_folder + @"\en.traineddata");
-            }
-            //
 
             int filesNeeded = 0;
             for (int i = 0; i < list_of_dlls.Length; i++)

--- a/WFInfo/Data.cs
+++ b/WFInfo/Data.cs
@@ -1231,7 +1231,7 @@ namespace WFInfo
                 RequestUri = new Uri("https://api.warframe.market/v1/auth/signin"),
                 Method = HttpMethod.Post,
             };
-            var content = $"{{ \"email\":\"{email}\",\"password\":\"{password.Replace(@"\", @"\\")}\", \"auth_type\": \"header\"}}";
+            var content = $"{{ \"email\":\"{email}\",\"password\":\"{password.Replace(@"\", @"\\").Replace("\"", "\\\"")}\", \"auth_type\": \"header\"}}";
             request.Content = new StringContent(content, System.Text.Encoding.UTF8, "application/json");
             request.Headers.Add("Authorization", "JWT");
             request.Headers.Add("language", "en");

--- a/WFInfo/Data.cs
+++ b/WFInfo/Data.cs
@@ -1522,7 +1522,7 @@ namespace WFInfo
         /// </summary>
         /// <param name="primeName"></param>
         /// <returns></returns>
-        public async Task<JObject> GetTopListings(string primeName) //https://api.warframe.market/v1/items/ prime_name /orders/top
+        public async Task<JObject> GetTopListings(string primeName)
         {
             var urlName = GetUrlName(primeName);
 
@@ -1530,7 +1530,7 @@ namespace WFInfo
             {
                 using (var request = new HttpRequestMessage()
                 {
-                    RequestUri = new Uri("https://api.warframe.market/v1/items/" + urlName + "/orders/top"),
+                    RequestUri = new Uri("https://api.warframe.market/v2/orders/item/" + urlName + "/top"),
                     Method = HttpMethod.Get
                 })
                 {

--- a/WFInfo/FodyWeavers.xsd
+++ b/WFInfo/FodyWeavers.xsd
@@ -29,12 +29,27 @@
               </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="Unmanaged32Assemblies" type="xs:string">
                 <xs:annotation>
-                  <xs:documentation>A list of unmanaged 32 bit assembly names to include, delimited with line breaks.</xs:documentation>
+                  <xs:documentation>Obsolete, use UnmanagedWinX86Assemblies instead</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="UnmanagedWinX86Assemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of unmanaged X86 (32 bit) assembly names to include, delimited with line breaks.</xs:documentation>
                 </xs:annotation>
               </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="Unmanaged64Assemblies" type="xs:string">
                 <xs:annotation>
-                  <xs:documentation>A list of unmanaged 64 bit assembly names to include, delimited with line breaks.</xs:documentation>
+                  <xs:documentation>Obsolete, use UnmanagedWinX64Assemblies instead.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="UnmanagedWinX64Assemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of unmanaged X64 (64 bit) assembly names to include, delimited with line breaks.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="UnmanagedWinArm64Assemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of unmanaged Arm64 (64 bit) assembly names to include, delimited with line breaks.</xs:documentation>
                 </xs:annotation>
               </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="PreloadOrder" type="xs:string">
@@ -73,6 +88,11 @@
                 <xs:documentation>As part of Costura, embedded assemblies are no longer included as part of the build. This cleanup can be turned off.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="DisableEventSubscription" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>The attach method no longer subscribes to the `AppDomain.AssemblyResolve` (.NET 4.x) and `AssemblyLoadContext.Resolving` (.NET 6.0+) events.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="LoadAtModuleInit" type="xs:boolean">
               <xs:annotation>
                 <xs:documentation>Costura by default will load as part of the module initialization. This flag disables that behavior. Make sure you call CosturaUtility.Initialize() somewhere in your code.</xs:documentation>
@@ -105,12 +125,27 @@
             </xs:attribute>
             <xs:attribute name="Unmanaged32Assemblies" type="xs:string">
               <xs:annotation>
-                <xs:documentation>A list of unmanaged 32 bit assembly names to include, delimited with |.</xs:documentation>
+                <xs:documentation>Obsolete, use UnmanagedWinX86Assemblies instead</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UnmanagedWinX86Assemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of unmanaged X86 (32 bit) assembly names to include, delimited with |.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="Unmanaged64Assemblies" type="xs:string">
               <xs:annotation>
-                <xs:documentation>A list of unmanaged 64 bit assembly names to include, delimited with |.</xs:documentation>
+                <xs:documentation>Obsolete, use UnmanagedWinX64Assemblies instead</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UnmanagedWinX64Assemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of unmanaged X64 (64 bit) assembly names to include, delimited with |.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UnmanagedWinArm64Assemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of unmanaged Arm64 (64 bit) assembly names to include, delimited with |.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="PreloadOrder" type="xs:string">

--- a/WFInfo/ListingHelper.xaml.cs
+++ b/WFInfo/ListingHelper.xaml.cs
@@ -377,7 +377,7 @@ namespace WFInfo
             Debug.WriteLine($"Getting listing for {primeName}");
             var results = Task.Run(async () => await Main.dataBase.GetTopListings(primeName)).Result;
             var listings = new List<MarketListing>();
-            var sellOrders = new JArray(results["payload"]["sell_orders"].Children());
+            var sellOrders = new JArray(results["data"]["sell"].Children());
             foreach (var item in sellOrders)
             {
                 var platinum = item.Value<short>("platinum");

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -66,7 +66,7 @@ namespace WFInfo
 															Color.FromArgb(140,  38,  92),  	//NIDUS			
 															Color.FromArgb( 20,  41,  29),  	//OROKIN		
 															Color.FromArgb(  9,  78, 106),  	//TENNO			
-															Color.FromArgb(  2, 127, 217),  	//HIGH_CONTRAST	
+															Color.FromArgb(102, 176, 255),  	//HIGH_CONTRAST	
 															Color.FromArgb(255, 255, 255),  	//LEGACY		
 															Color.FromArgb(158, 159, 167),  	//EQUINOX		
 															Color.FromArgb(140, 119, 147),      //DARK_LOTUS
@@ -1921,7 +1921,7 @@ namespace WFInfo
                 case WFtheme.FORTUNA:
                     return ((Math.Abs(test.GetHue() - primary.GetHue()) < 3 && test.GetBrightness() >= 0.35) || (Math.Abs(test.GetHue() - secondary.GetHue()) < 4 && test.GetBrightness() >= 0.15)) && test.GetSaturation() >= 0.20;
                 case WFtheme.HIGH_CONTRAST:
-                    return (Math.Abs(test.GetHue() - primary.GetHue()) < 3 || Math.Abs(test.GetHue() - secondary.GetHue()) < 2) && test.GetSaturation() >= 0.75 && test.GetBrightness() >= 0.35; // || Math.Abs(test.GetHue() - secondary.GetHue()) < 2;
+                    return (Math.Abs(test.GetHue() - primary.GetHue()) < 3 || Math.Abs(test.GetHue() - secondary.GetHue()) < 2) && test.GetSaturation() >= 0.49 && test.GetBrightness() >= 0.35; // || Math.Abs(test.GetHue() - secondary.GetHue()) < 2;
                 case WFtheme.LEGACY:    // TO CHECK
                     return (test.GetBrightness() >= 0.65)
                         || (Math.Abs(test.GetHue() - secondary.GetHue()) < 6 && test.GetBrightness() >= 0.5 && test.GetSaturation() >= 0.5);

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -1917,7 +1917,7 @@ namespace WFInfo
                     return test.GetSaturation() <= 0.2 && test.GetBrightness() >= 0.55;
                 case WFtheme.DARK_LOTUS:
                     return (Math.Abs(test.GetHue() - primary.GetHue()) < 15 && test.GetBrightness() >= 0.35 && test.GetBrightness() <= 0.55 && test.GetBrightness() >= 0.40 && test.GetSaturation() <= 0.20 && test.GetSaturation() >= 0.05)
-                        || (Math.Abs(test.GetHue() - secondary.GetHue()) < 4 && test.GetBrightness() >= 0.60 && test.GetSaturation() >= 0.30 && test.GetSaturation() <= 70);
+                        || (Math.Abs(test.GetHue() - secondary.GetHue()) < 4 && test.GetBrightness() >= 0.60 && test.GetSaturation() >= 0.30 && test.GetSaturation() <= 0.70);
                 case WFtheme.FORTUNA:
                     return ((Math.Abs(test.GetHue() - primary.GetHue()) < 3 && test.GetBrightness() >= 0.35) || (Math.Abs(test.GetHue() - secondary.GetHue()) < 4 && test.GetBrightness() >= 0.15)) && test.GetSaturation() >= 0.20;
                 case WFtheme.HIGH_CONTRAST:

--- a/WFInfo/Ocr.cs
+++ b/WFInfo/Ocr.cs
@@ -86,7 +86,7 @@ namespace WFInfo
 															Color.FromArgb(255, 255,   0),  	//HIGH_CONTRAST	
 															Color.FromArgb(232, 213,  93),  	//LEGACY		
 															Color.FromArgb(232, 227, 227),  	//EQUINOX		
-															Color.FromArgb(189, 169, 237),      //DARK_LOTUS	
+															Color.FromArgb(200, 169, 237),      //DARK_LOTUS	
                                                             Color.FromArgb(255,  53,   0) };    //ZEPHER	
 
 
@@ -1916,8 +1916,8 @@ namespace WFInfo
                 case WFtheme.EQUINOX:
                     return test.GetSaturation() <= 0.2 && test.GetBrightness() >= 0.55;
                 case WFtheme.DARK_LOTUS:
-                    return (Math.Abs(test.GetHue() - secondary.GetHue()) < 20 && test.GetBrightness() >= 0.35 && test.GetBrightness() <= 0.55 && test.GetSaturation() <= 0.25 && test.GetSaturation() >= 0.05)
-                        || (Math.Abs(test.GetHue() - secondary.GetHue()) < 4 && test.GetBrightness() >= 0.50 && test.GetSaturation() >= 0.20);
+                    return (Math.Abs(test.GetHue() - primary.GetHue()) < 15 && test.GetBrightness() >= 0.35 && test.GetBrightness() <= 0.55 && test.GetBrightness() >= 0.40 && test.GetSaturation() <= 0.20 && test.GetSaturation() >= 0.05)
+                        || (Math.Abs(test.GetHue() - secondary.GetHue()) < 4 && test.GetBrightness() >= 0.60 && test.GetSaturation() >= 0.30 && test.GetSaturation() <= 70);
                 case WFtheme.FORTUNA:
                     return ((Math.Abs(test.GetHue() - primary.GetHue()) < 3 && test.GetBrightness() >= 0.35) || (Math.Abs(test.GetHue() - secondary.GetHue()) < 4 && test.GetBrightness() >= 0.15)) && test.GetSaturation() >= 0.20;
                 case WFtheme.HIGH_CONTRAST:

--- a/WFInfo/Services/Screenshot/GdiScreenshotService.cs
+++ b/WFInfo/Services/Screenshot/GdiScreenshotService.cs
@@ -45,7 +45,7 @@ namespace WFInfo.Services.Screenshot
                 height *= (int)_window.DpiScaling;
             }
 
-            Bitmap image = new Bitmap(width, height);
+            Bitmap image = new Bitmap(width, height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
             Size FullscreenSize = new Size(image.Width, image.Height);
 
             using (Graphics graphics = Graphics.FromImage(image))

--- a/WFInfo/Services/Screenshot/ImageScreenshotService.cs
+++ b/WFInfo/Services/Screenshot/ImageScreenshotService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -26,7 +27,18 @@ namespace WFInfo.Services.Screenshot
                 {
                     try
                     {
-                        var tasks = openFileDialog.FileNames.Select(file => Task.Run(() => new Bitmap(file)));
+                        var tasks = openFileDialog.FileNames.Select(file => Task.Run(() =>
+                        {
+                            using (Bitmap rawImage = new Bitmap(file))
+                            {
+                                Bitmap correctedPixelFormat = new Bitmap(rawImage.Width, rawImage.Height, PixelFormat.Format32bppArgb);
+                                using (Graphics graphics = Graphics.FromImage(correctedPixelFormat))
+                                {
+                                    graphics.DrawImage(rawImage, 0, 0);
+                                }
+                                return correctedPixelFormat;
+                            }
+                        }));
                         var images = await Task.WhenAll(tasks);
                         return images.ToList();
                     }

--- a/WFInfo/Services/Screenshot/WindowsCaptureScreenshotService.cs
+++ b/WFInfo/Services/Screenshot/WindowsCaptureScreenshotService.cs
@@ -95,7 +95,14 @@ namespace WFInfo.Services.Screenshot
             _d3dDevice.ImmediateContext.UnmapSubresource(cpuTexture, 0);
             cpuTexture.Dispose();
 
-            var result = new List<Bitmap> { bitmap };
+            Bitmap correctedPixelFormat = new Bitmap(bitmap.Width, bitmap.Height, PixelFormat.Format32bppArgb);
+            using (Graphics graphics = Graphics.FromImage(correctedPixelFormat))
+            {
+                graphics.DrawImage(bitmap, 0, 0);
+            }
+            bitmap.Dispose();
+
+            var result = new List<Bitmap> { correctedPixelFormat };
             return Task.FromResult(result);
         }
 

--- a/WFInfo/WFInfo.csproj
+++ b/WFInfo/WFInfo.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>WinExe</OutputType>
@@ -40,6 +40,10 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DebugType>embedded</DebugType>
+	<DeterministicSourcePaths>True</DeterministicSourcePaths>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Net.Http" />


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
- Swapped to embedded pdb file, giving more line numbers in stack traces. 
  - Enabled DeterministicSourcePaths, so repo location of whoever built it is excluded
- Fixed HDR using wrong pixel format, breaking Count Item.
- Migrated GetTopListings method to V2 API
  - The V1 endpoint for this temporarily broke a few months ago. It got fixed soon after we reported it to WFM, but migrating it still feels like the right move.
  - I did **NOT** fix the deadlock in GetRewardCollection if an exception occurs
- Add tesseract traineddata fallback location. Necessary in case windows username contains any non-english letters.
- Updated colors/filter for High Contrast theme
  - In-game colors for it were changed back in October. Since then, the workaround has been to use a custom theme.
- Updated colors/filter for Dark Lotus theme
  - Decided to give it a shot while I was doing High Contrast. Seems to actually be usable, unlike before.
- Closes #335 - Added escape for " in WFM password

If you want any of this excluded or split into separate PR:s, just ask. The commits are cleanly separated, so it can easily be done.

---

### Reproduction steps

#### HDR Pixel Format
1. Enable HDR in-game and ensure the HDR screenshotting method gets used
2. Tune theme to work
3. Try snap-it with item count enabled. Resulting count will either always be 1, or an error will occur due to differing pixel size

#### GetTopListings
1. (Optional) If you wish to reproduce the deadlock, simply return null in GetTopListings
2. Use Search It

#### Tessseract fallback location
1. Have a windows username containing a non-english letter. 
Alternatively, see chat history from ticket 474276810243178507 for confirmation it works

#### High Contrast/Dark Lotus theme
1. Try to use Snap It or reward screen scanning with the corresponding theme, with auto theme detection

#### " in WFM password
1. Change your WFM password to contain "
2. Try to log in from within WFInfo

---

### Evidence/screenshot/link to line

See individual commits

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix/Maintenance]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved support for multiple system architectures in configuration, including new options for 32-bit, 64-bit, and ARM64 unmanaged assemblies.
  - Added a fallback mechanism for OCR data files to enhance compatibility with non-English file paths.

- **Bug Fixes**
  - Updated market API endpoints and adjusted JSON parsing to ensure continued compatibility with external services.
  - Improved password handling during login to better escape special characters.
  - Corrected image and screenshot handling to ensure consistent color depth and transparency.

- **Enhancements**
  - Refined color filtering for OCR themes to improve accuracy.
  - Updated build configuration for release builds to include embedded debug information and deterministic source paths.

- **Documentation**
  - Marked certain configuration options as obsolete and provided guidance on new replacements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->